### PR TITLE
fix: move cleanup annotation to the session bean

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/ArmadilloSession.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/ArmadilloSession.java
@@ -3,7 +3,6 @@ package org.molgenis.armadillo;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import javax.annotation.PreDestroy;
 import org.molgenis.armadillo.exceptions.ArmadilloSessionException;
 import org.molgenis.armadillo.service.ArmadilloConnectionFactory;
 import org.rosuda.REngine.Rserve.RConnection;
@@ -52,7 +51,6 @@ public class ArmadilloSession {
     }
   }
 
-  @PreDestroy
   public synchronized void sessionCleanup() {
     try {
       if (rSession != null) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import javax.annotation.PreDestroy;
 import org.molgenis.armadillo.ArmadilloSession;
 import org.molgenis.armadillo.command.ArmadilloCommand;
 import org.molgenis.armadillo.command.ArmadilloCommandDTO;
@@ -172,5 +173,10 @@ class CommandsImpl implements Commands {
             return packageService.getInstalledPackages(connection);
           }
         });
+  }
+
+  @PreDestroy
+  public void preDestroy() {
+    armadilloSession.sessionCleanup();
   }
 }


### PR DESCRIPTION
Initially, `ArmadilloSession` was the bean with `@SessionScope`.
But we had to keep track of the last command so the `CommandsImpl` became the session bean.
That's when we should've moved the `@PreDestroy` cleanup method to the `CommandsImpl` as well :)