### PR TITLE
feat: expose r process info on actuator endpoints

### DIFF
--- a/armadillo/pom.xml
+++ b/armadillo/pom.xml
@@ -78,6 +78,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RMetrics.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RMetrics.java
@@ -10,12 +10,7 @@ public class RMetrics {
   @Bean
   MeterBinder rProcesses(RProcessEndpoint processes) {
     return registry ->
-        Gauge.builder(
-                "rserve_processes_current",
-                () ->
-                    processes.getRProcesses().stream()
-                        .filter(it -> it.name().startsWith("Rserve"))
-                        .count())
+        Gauge.builder("rserve.processes.current", processes::countRServeProcesses)
             .description("Current number of RServe processes on the R server")
             .register(registry);
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RMetrics.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RMetrics.java
@@ -1,0 +1,22 @@
+package org.molgenis.armadillo.info;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RMetrics {
+  @Bean
+  MeterBinder rProcesses(RProcessEndpoint processes) {
+    return registry ->
+        Gauge.builder(
+                "rserve_processes_current",
+                () ->
+                    processes.getRProcesses().stream()
+                        .filter(it -> it.name().startsWith("Rserve"))
+                        .count())
+            .description("Current number of RServe processes on the R server")
+            .register(registry);
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
@@ -3,29 +3,37 @@ package org.molgenis.armadillo.info;
 import java.util.List;
 import org.molgenis.r.RConnectionFactory;
 import org.molgenis.r.model.RProcess;
-import org.molgenis.r.service.ProcessServiceImpl;
+import org.molgenis.r.service.ProcessService;
 import org.rosuda.REngine.Rserve.RConnection;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.stereotype.Component;
 
 @Component
-@Endpoint(id = "r-processes")
+@Endpoint(id = "rserveProcesses")
 public class RProcessEndpoint {
-  private final ProcessServiceImpl processService;
+  private final ProcessService processService;
   private final RConnectionFactory rConnectionFactory;
 
-  public RProcessEndpoint(
-      ProcessServiceImpl processService, RConnectionFactory rConnectionFactory) {
+  public RProcessEndpoint(ProcessService processService, RConnectionFactory rConnectionFactory) {
     this.processService = processService;
     this.rConnectionFactory = rConnectionFactory;
   }
 
   @ReadOperation
-  public List<RProcess> getRProcesses() {
+  public List<RProcess> getRServeProcesses() {
     final RConnection connection = rConnectionFactory.createConnection();
     try {
-      return processService.getProcesses(connection);
+      return processService.getRserveProcesses(connection);
+    } finally {
+      connection.close();
+    }
+  }
+
+  public int countRServeProcesses() {
+    final RConnection connection = rConnectionFactory.createConnection();
+    try {
+      return processService.countRserveProcesses(connection);
     } finally {
       connection.close();
     }

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
@@ -1,0 +1,33 @@
+package org.molgenis.armadillo.info;
+
+import java.util.List;
+import org.molgenis.r.RConnectionFactory;
+import org.molgenis.r.model.RProcess;
+import org.molgenis.r.service.ProcessServiceImpl;
+import org.rosuda.REngine.Rserve.RConnection;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "r-processes")
+public class RProcessEndpoint {
+  private final ProcessServiceImpl processService;
+  private final RConnectionFactory rConnectionFactory;
+
+  public RProcessEndpoint(
+      ProcessServiceImpl processService, RConnectionFactory rConnectionFactory) {
+    this.processService = processService;
+    this.rConnectionFactory = rConnectionFactory;
+  }
+
+  @ReadOperation
+  public List<RProcess> getRProcesses() {
+    final RConnection connection = rConnectionFactory.createConnection();
+    try {
+      return processService.getProcesses(connection);
+    } finally {
+      connection.close();
+    }
+  }
+}

--- a/r/src/main/java/org/molgenis/r/REXPParser.java
+++ b/r/src/main/java/org/molgenis/r/REXPParser.java
@@ -22,8 +22,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class REXPParser {
 
-  public Instant parseDate(Double date) {
-    return Instant.ofEpochMilli(Math.round(date * 1000));
+  public Optional<Instant> parseDate(Double date) {
+    return Optional.ofNullable(date).map(it -> Math.round(it * 1000)).map(Instant::ofEpochMilli);
   }
 
   /**
@@ -72,7 +72,7 @@ public class REXPParser {
     return rows;
   }
 
-  Optional<? extends Object> getValueAtIndex(REXPVector values, int rowNum)
+  Optional<Object> getValueAtIndex(REXPVector values, int rowNum)
       throws REXPMismatchException {
     if (values.isNA()[rowNum]) {
       return Optional.empty();

--- a/r/src/main/java/org/molgenis/r/REXPParser.java
+++ b/r/src/main/java/org/molgenis/r/REXPParser.java
@@ -1,21 +1,30 @@
 package org.molgenis.r;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.rosuda.REngine.REXPLogical.TRUE;
 
 import com.google.common.collect.Lists;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.REXPString;
+import org.rosuda.REngine.REXPVector;
 import org.rosuda.REngine.RList;
 import org.springframework.stereotype.Component;
 
 /** Parses REXP objects returned from Rserve */
 @Component
 public class REXPParser {
+
+  public Instant parseDate(Double date) {
+    return Instant.ofEpochMilli(Math.round(date * 1000));
+  }
 
   /**
    * Parses 2D R string matrix to a list of String maps
@@ -46,5 +55,38 @@ public class REXPParser {
       result.add(row);
     }
     return result;
+  }
+
+  public List<Map<String, Object>> parseTibble(RList list) throws REXPMismatchException {
+    List<Map<String, Object>> rows = newArrayList();
+    var numRows = ((REXPVector) list.get(list.names.get(0))).length();
+    for (int rowNum = 0; rowNum < numRows; rowNum++) {
+      Map<String, Object> converted = new LinkedHashMap<>();
+      rows.add(converted);
+      for (Object key : list.names) {
+        String name = (String) key;
+        REXPVector values = (REXPVector) list.get(name);
+        getValueAtIndex(values, rowNum).ifPresent(value -> converted.put(name, value));
+      }
+    }
+    return rows;
+  }
+
+  Optional<? extends Object> getValueAtIndex(REXPVector values, int rowNum)
+      throws REXPMismatchException {
+    if (values.isNA()[rowNum]) {
+      return Optional.empty();
+    }
+    if (values.isInteger()) {
+      return Optional.of(values.asIntegers()[rowNum]);
+    } else if (values.isLogical()) {
+      return Optional.of(values.asIntegers()[rowNum]).map(it -> Integer.valueOf(TRUE).equals(it));
+    } else if (values.isNumeric()) {
+      return Optional.of(values.asDoubles()[rowNum]);
+    } else if (values.isString()) {
+      return Optional.ofNullable(values.asStrings()[rowNum]);
+    } else {
+      return Optional.empty();
+    }
   }
 }

--- a/r/src/main/java/org/molgenis/r/REXPParser.java
+++ b/r/src/main/java/org/molgenis/r/REXPParser.java
@@ -72,8 +72,7 @@ public class REXPParser {
     return rows;
   }
 
-  Optional<Object> getValueAtIndex(REXPVector values, int rowNum)
-      throws REXPMismatchException {
+  Optional<Object> getValueAtIndex(REXPVector values, int rowNum) throws REXPMismatchException {
     if (values.isNA()[rowNum]) {
       return Optional.empty();
     }

--- a/r/src/main/java/org/molgenis/r/model/RProcess.java
+++ b/r/src/main/java/org/molgenis/r/model/RProcess.java
@@ -27,24 +27,30 @@ public abstract class RProcess {
     WAKING;
   }
 
+  @Nullable
   @JsonProperty("pid")
-  public abstract int pid();
+  public abstract Integer pid();
 
+  @Nullable
   @JsonProperty("ppid")
-  public abstract int pPid();
+  public abstract Integer pPid();
 
+  @Nullable
   @JsonProperty("name")
   public abstract String name();
 
+  @Nullable
   @JsonProperty("cmd")
   public abstract String cmd();
 
+  @Nullable
   @JsonProperty("username")
   public abstract String username();
 
   @JsonProperty("ports")
   public abstract List<Integer> ports();
 
+  @Nullable
   @JsonProperty("status")
   public abstract Status status();
 
@@ -64,14 +70,15 @@ public abstract class RProcess {
   @JsonProperty("vms")
   public abstract Double vms();
 
+  @Nullable
   @JsonProperty("created")
   public abstract Instant created();
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setPid(int pid);
+    public abstract Builder setPid(Integer pid);
 
-    public abstract Builder setPPid(int ppid);
+    public abstract Builder setPPid(Integer ppid);
 
     public abstract Builder setName(String name);
 
@@ -97,6 +104,6 @@ public abstract class RProcess {
   }
 
   public static Builder builder() {
-    return new AutoValue_RProcess.Builder().setPorts(List.of()).setCmd("Unknown");
+    return new AutoValue_RProcess.Builder().setPorts(List.of());
   }
 }

--- a/r/src/main/java/org/molgenis/r/model/RProcess.java
+++ b/r/src/main/java/org/molgenis/r/model/RProcess.java
@@ -1,0 +1,102 @@
+package org.molgenis.r.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.value.AutoValue;
+import java.time.Instant;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.molgenis.r.model.RPackage.Builder;
+
+@AutoValue
+@JsonSerialize(as = RProcess.class)
+@JsonInclude(Include.NON_NULL)
+public abstract class RProcess {
+  public enum Status {
+    IDLE,
+    RUNNING,
+    SLEEPING,
+    DISK_SLEEP,
+    STOPPED,
+    TRACING_STOP,
+    ZOMBIE,
+    DEAD,
+    WAKE_KILL,
+    WAKING;
+  }
+
+  @JsonProperty("pid")
+  public abstract int pid();
+
+  @JsonProperty("ppid")
+  public abstract int pPid();
+
+  @JsonProperty("name")
+  public abstract String name();
+
+  @JsonProperty("cmd")
+  public abstract String cmd();
+
+  @JsonProperty("username")
+  public abstract String username();
+
+  @JsonProperty("ports")
+  public abstract List<Integer> ports();
+
+  @JsonProperty("status")
+  public abstract Status status();
+
+  @Nullable
+  @JsonProperty("user")
+  public abstract Double user();
+
+  @Nullable
+  @JsonProperty("system")
+  public abstract Double system();
+
+  @Nullable
+  @JsonProperty("rss")
+  public abstract Double rss();
+
+  @Nullable
+  @JsonProperty("vms")
+  public abstract Double vms();
+
+  @JsonProperty("created")
+  public abstract Instant created();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setPid(int pid);
+
+    public abstract Builder setPPid(int ppid);
+
+    public abstract Builder setName(String name);
+
+    public abstract Builder setCmd(String name);
+
+    public abstract Builder setUsername(String username);
+
+    public abstract Builder setPorts(List<Integer> ports);
+
+    public abstract Builder setStatus(Status status);
+
+    public abstract Builder setUser(Double user);
+
+    public abstract Builder setSystem(Double system);
+
+    public abstract Builder setRss(Double rss);
+
+    public abstract Builder setVms(Double vms);
+
+    public abstract Builder setCreated(Instant created);
+
+    public abstract RProcess build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_RProcess.Builder().setPorts(List.of()).setCmd("Unknown");
+  }
+}

--- a/r/src/main/java/org/molgenis/r/service/ProcessService.java
+++ b/r/src/main/java/org/molgenis/r/service/ProcessService.java
@@ -5,5 +5,8 @@ import org.molgenis.r.model.RProcess;
 import org.rosuda.REngine.Rserve.RConnection;
 
 public interface ProcessService {
-  List<RProcess> getProcesses(RConnection connection);
+
+  int countRserveProcesses(RConnection connection);
+
+  List<RProcess> getRserveProcesses(RConnection connection);
 }

--- a/r/src/main/java/org/molgenis/r/service/ProcessService.java
+++ b/r/src/main/java/org/molgenis/r/service/ProcessService.java
@@ -1,0 +1,9 @@
+package org.molgenis.r.service;
+
+import java.util.List;
+import org.molgenis.r.model.RProcess;
+import org.rosuda.REngine.Rserve.RConnection;
+
+public interface ProcessService {
+  List<RProcess> getProcesses(RConnection connection);
+}

--- a/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
@@ -1,0 +1,79 @@
+package org.molgenis.r.service;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.molgenis.r.REXPParser;
+import org.molgenis.r.exceptions.RExecutionException;
+import org.molgenis.r.model.RProcess;
+import org.molgenis.r.model.RProcess.Status;
+import org.rosuda.REngine.REXPMismatchException;
+import org.rosuda.REngine.Rserve.RConnection;
+import org.rosuda.REngine.Rserve.RserveException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessServiceImpl implements ProcessService {
+
+  public static final String GET_PROCESSES_COMMAND =
+      "library(magrittr)\n"
+          + "getPorts <- function(handle) {\n"
+          + "  tryCatch(ps::ps_connections(handle) %>%\n"
+          + "    dplyr::filter(is.integer(lport) & !is.na(lport)) %>%\n"
+          + "    dplyr::pull(lport) %>%\n"
+          + "    paste0(collapse = \" \"), error = function(e) {NA})\n"
+          + "}\n"
+          + "\n"
+          + "getCmd <- function(handle) {\n"
+          + "  tryCatch(ps::ps_cmdline(handle) %>%\n"
+          + "             paste0(collapse = \" \"), error = function(e) {NA})\n"
+          + "}\n"
+          + "\n"
+          + "dplyr::mutate(\n"
+          + "  ps::ps(),\n"
+          + "  ports = sapply(ps_handle, getPorts, simplify = \"vector\"),\n"
+          + "  cmd = sapply(ps_handle, getCmd, simplify = \"vector\")\n"
+          + ")";
+  private final REXPParser rexpParser;
+
+  public ProcessServiceImpl(REXPParser rexpParser) {
+    this.rexpParser = rexpParser;
+  }
+
+  @Override
+  public List<RProcess> getProcesses(RConnection connection) {
+    try {
+      var result = connection.eval(GET_PROCESSES_COMMAND).asList();
+      return rexpParser.parseTibble(result).stream().map(this::toRProcess).collect(toList());
+    } catch (RserveException | REXPMismatchException e) {
+      throw new RExecutionException(e);
+    }
+  }
+
+  private RProcess toRProcess(Map<String, Object> values) {
+    var ports =
+        Optional.ofNullable((String) values.get("ports"))
+            .filter(it -> !it.isEmpty())
+            .map(it -> it.split(" "))
+            .map(it -> Arrays.stream(it).map(Integer::parseInt).collect(toList()))
+            .orElse(List.of());
+    var builder =
+        RProcess.builder()
+            .setPid((Integer) values.get("pid"))
+            .setPPid((Integer) values.get("ppid"))
+            .setName((String) values.get("name"))
+            .setCmd((String) values.get("cmd"))
+            .setUsername((String) values.get("username"))
+            .setStatus(Status.valueOf(((String) values.get("status")).toUpperCase()))
+            .setCreated(rexpParser.parseDate((Double) values.get("created")))
+            .setPorts(ports);
+    Optional.ofNullable((Double) values.get("user")).ifPresent(builder::setUser);
+    Optional.ofNullable((Double) values.get("system")).ifPresent(builder::setSystem);
+    Optional.ofNullable((Double) values.get("rss")).ifPresent(builder::setRss);
+    Optional.ofNullable((Double) values.get("vms")).ifPresent(builder::setVms);
+    return builder.build();
+  }
+}

--- a/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
@@ -2,6 +2,7 @@ package org.molgenis.r.service;
 
 import static java.util.stream.Collectors.toList;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class ProcessServiceImpl implements ProcessService {
             .setCmd((String) values.get("cmd"))
             .setUsername((String) values.get("username"))
             .setStatus(Status.valueOf(((String) values.get("status")).toUpperCase()))
-            .setCreated(rexpParser.parseDate((Double) values.get("created")))
+            .setCreated(rexpParser.parseDate((Double) values.get("created")).orElse(Instant.EPOCH))
             .setPorts(ports);
     Optional.ofNullable((Double) values.get("user")).ifPresent(builder::setUser);
     Optional.ofNullable((Double) values.get("system")).ifPresent(builder::setSystem);

--- a/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/ProcessServiceImpl.java
@@ -2,7 +2,6 @@ package org.molgenis.r.service;
 
 import static java.util.stream.Collectors.toList;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +10,7 @@ import org.molgenis.r.REXPParser;
 import org.molgenis.r.exceptions.RExecutionException;
 import org.molgenis.r.model.RProcess;
 import org.molgenis.r.model.RProcess.Status;
+import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.Rserve.RConnection;
 import org.rosuda.REngine.Rserve.RserveException;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProcessServiceImpl implements ProcessService {
 
-  public static final String GET_PROCESSES_COMMAND =
+  public static final String GET_RSERVE_PROCESSES_COMMAND =
       "library(magrittr)\n"
           + "getPorts <- function(handle) {\n"
           + "  tryCatch(ps::ps_connections(handle) %>%\n"
@@ -33,11 +33,19 @@ public class ProcessServiceImpl implements ProcessService {
           + "             paste0(collapse = \" \"), error = function(e) {NA})\n"
           + "}\n"
           + "\n"
+          + "ps::ps() %>%\n"
+          + "  dplyr::filter(grepl(\"Rserve\", name)) %>%\n"
+          + "  "
           + "dplyr::mutate(\n"
-          + "  ps::ps(),\n"
-          + "  ports = sapply(ps_handle, getPorts, simplify = \"vector\"),\n"
-          + "  cmd = sapply(ps_handle, getCmd, simplify = \"vector\")\n"
-          + ")";
+          + "    ports = sapply(ps_handle, getPorts, simplify = \"vector\"),\n"
+          + "    cmd = sapply(ps_handle, getCmd, simplify = \"vector\")\n"
+          + "  "
+          + ") ";
+  public static final String COUNT_RSERVE_PROCESSES_COMMAND =
+      "library(magrittr)\n"
+          + "ps::ps() %>%\n"
+          + "  dplyr::filter(grepl(\"Rserve\", name)) %>%\n"
+          + "  dplyr::count()";
   private final REXPParser rexpParser;
 
   public ProcessServiceImpl(REXPParser rexpParser) {
@@ -45,9 +53,18 @@ public class ProcessServiceImpl implements ProcessService {
   }
 
   @Override
-  public List<RProcess> getProcesses(RConnection connection) {
+  public int countRserveProcesses(RConnection connection) {
     try {
-      var result = connection.eval(GET_PROCESSES_COMMAND).asList();
+      return ((REXP) connection.eval(COUNT_RSERVE_PROCESSES_COMMAND).asList().get(0)).asInteger();
+    } catch (RserveException | REXPMismatchException | ClassCastException e) {
+      throw new RExecutionException(e);
+    }
+  }
+
+  @Override
+  public List<RProcess> getRserveProcesses(RConnection connection) {
+    try {
+      var result = connection.eval(GET_RSERVE_PROCESSES_COMMAND).asList();
       return rexpParser.parseTibble(result).stream().map(this::toRProcess).collect(toList());
     } catch (RserveException | REXPMismatchException e) {
       throw new RExecutionException(e);
@@ -55,22 +72,24 @@ public class ProcessServiceImpl implements ProcessService {
   }
 
   private RProcess toRProcess(Map<String, Object> values) {
-    var ports =
-        Optional.ofNullable((String) values.get("ports"))
-            .filter(it -> !it.isEmpty())
-            .map(it -> it.split(" "))
-            .map(it -> Arrays.stream(it).map(Integer::parseInt).collect(toList()))
-            .orElse(List.of());
-    var builder =
-        RProcess.builder()
-            .setPid((Integer) values.get("pid"))
-            .setPPid((Integer) values.get("ppid"))
-            .setName((String) values.get("name"))
-            .setCmd((String) values.get("cmd"))
-            .setUsername((String) values.get("username"))
-            .setStatus(Status.valueOf(((String) values.get("status")).toUpperCase()))
-            .setCreated(rexpParser.parseDate((Double) values.get("created")).orElse(Instant.EPOCH))
-            .setPorts(ports);
+    var builder = RProcess.builder();
+    Optional.ofNullable((Integer) values.get("pid")).ifPresent(builder::setPid);
+    Optional.ofNullable((Integer) values.get("ppid")).ifPresent(builder::setPPid);
+    Optional.ofNullable((String) values.get("name")).ifPresent(builder::setName);
+    Optional.ofNullable((String) values.get("cmd")).ifPresent(builder::setCmd);
+    Optional.ofNullable((String) values.get("username")).ifPresent(builder::setUsername);
+    Optional.ofNullable((String) values.get("status"))
+        .map(String::toUpperCase)
+        .map(Status::valueOf)
+        .ifPresent(builder::setStatus);
+    Optional.ofNullable((Double) values.get("created"))
+        .flatMap(rexpParser::parseDate)
+        .ifPresent(builder::setCreated);
+    Optional.ofNullable((String) values.get("ports"))
+        .filter(it -> !it.isEmpty())
+        .map(it -> it.split(" "))
+        .map(it -> Arrays.stream(it).map(Integer::parseInt).collect(toList()))
+        .ifPresent(builder::setPorts);
     Optional.ofNullable((Double) values.get("user")).ifPresent(builder::setUser);
     Optional.ofNullable((Double) values.get("system")).ifPresent(builder::setSystem);
     Optional.ofNullable((Double) values.get("rss")).ifPresent(builder::setRss);

--- a/r/src/test/java/org/molgenis/r/REXPParserTest.java
+++ b/r/src/test/java/org/molgenis/r/REXPParserTest.java
@@ -5,10 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.rosuda.REngine.REXP;
+import org.rosuda.REngine.REXPDouble;
 import org.rosuda.REngine.REXPGenericVector;
+import org.rosuda.REngine.REXPInteger;
 import org.rosuda.REngine.REXPList;
+import org.rosuda.REngine.REXPLogical;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.REXPString;
 import org.rosuda.REngine.RList;
@@ -38,5 +46,94 @@ class REXPParserTest {
             Map.of("Package", "base", "Version", "1.0.1"),
             Map.of("Package", "desc", "Version", "1.2.3")),
         rexpParser.toStringMap(rexpString));
+  }
+
+  @Test
+  void parseTibbleTransposesTheDataStructure() throws REXPMismatchException {
+    RList rList =
+        new RList(
+            List.of(
+                new REXPString(new String[] {"id1", "id2"}),
+                new REXPString(new String[] {"label1", "label2"})),
+            new String[] {"id", "label"});
+    var parsed = rexpParser.parseTibble(rList);
+
+    assertEquals(
+        List.of(Map.of("id", "id1", "label", "label1"), Map.of("id", "id2", "label", "label2")),
+        parsed);
+  }
+
+  @Test
+  void parseTibbleSkipsNAValues() throws REXPMismatchException {
+    RList rList =
+        new RList(
+            List.of(
+                new REXPString(new String[] {"id1", "id2"}),
+                new REXPLogical(new byte[] {REXPLogical.NA, REXPLogical.FALSE})),
+            new String[] {"id", "valid"});
+    var parsed = rexpParser.parseTibble(rList);
+
+    assertEquals(List.of(Map.of("id", "id1"), Map.of("id", "id2", "valid", false)), parsed);
+  }
+
+  @Test
+  void parseTibbleSkipsNullValues() throws REXPMismatchException {
+    RList rList =
+        new RList(
+            List.of(
+                new REXPString(new String[] {"id1", "id2"}),
+                new REXPString(new String[] {null, "label2"})),
+            new String[] {"id", "label"});
+    var parsed = rexpParser.parseTibble(rList);
+
+    assertEquals(List.of(Map.of("id", "id1"), Map.of("id", "id2", "label", "label2")), parsed);
+  }
+
+  @ParameterizedTest
+  @MethodSource("logicalsProvider")
+  void getValueAtIndexParsesLogicals(byte logical, Optional<Boolean> expected)
+      throws REXPMismatchException {
+    var parsed = rexpParser.getValueAtIndex(new REXPLogical(logical), 0);
+    assertEquals(expected, parsed);
+  }
+
+  static Stream<Arguments> logicalsProvider() {
+    return Stream.of(
+        Arguments.of(REXPLogical.TRUE, Optional.of(true)),
+        Arguments.of(REXPLogical.FALSE, Optional.of(false)),
+        Arguments.of(REXPLogical.NA, Optional.<Boolean>empty()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("doublesProvider")
+  void getValueAtIndexParsesDoubles(Double value, Optional<Double> expected)
+      throws REXPMismatchException {
+    var parsed = rexpParser.getValueAtIndex(new REXPDouble(value), 0);
+    assertEquals(expected, parsed);
+  }
+
+  static Stream<Arguments> doublesProvider() {
+    return Stream.of(
+        Arguments.of(0.0, Optional.of(0.0)), Arguments.of(REXPDouble.NA, Optional.empty()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("intsProvider")
+  void getValueAtIndexParsesIntegers(int value, Optional<Integer> expected)
+      throws REXPMismatchException {
+    var parsed = rexpParser.getValueAtIndex(new REXPInteger(value), 0);
+    assertEquals(expected, parsed);
+  }
+
+  static Stream<Arguments> intsProvider() {
+    return Stream.of(
+        Arguments.of(0, Optional.of(0)), Arguments.of(REXPInteger.NA, Optional.empty()));
+  }
+
+  @Test
+  void getValueAtIndexSkipsTheUnknown() throws REXPMismatchException {
+    var vector = new REXPGenericVector(dimnames);
+    var parsed = rexpParser.getValueAtIndex(vector, 0);
+    assertEquals(Optional.empty(), parsed);
   }
 }

--- a/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
+++ b/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.molgenis.r.REXPParser;
 import org.molgenis.r.model.RProcess;
 import org.molgenis.r.model.RProcess.Status;
+import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.REXPString;
 import org.rosuda.REngine.RList;
@@ -28,6 +29,7 @@ class ProcessServiceImplTest {
   @Mock private REXPParser rexpParser;
   @Mock private REXPString rexp;
   @Mock private RList list;
+  @Mock private REXP row;
   @Mock private RConnection rConnection;
 
   private ProcessService processService;
@@ -38,7 +40,17 @@ class ProcessServiceImplTest {
   }
 
   @Test
-  void testGetProcesses() throws REXPMismatchException, RserveException {
+  void testCountRserveProcesses() throws REXPMismatchException, RserveException {
+    when(rConnection.eval(anyString())).thenReturn(rexp);
+    when(rexp.asList()).thenReturn(list);
+    when(list.get(0)).thenReturn(row);
+    when(row.asInteger()).thenReturn(3);
+
+    assertEquals(3, processService.countRserveProcesses(rConnection));
+  }
+
+  @Test
+  void testGetRserveProcesses() throws REXPMismatchException, RserveException {
     when(rConnection.eval(anyString())).thenReturn(rexp);
     when(rexp.asList()).thenReturn(list);
     when(rexpParser.parseTibble(list))
@@ -103,6 +115,6 @@ class ProcessServiceImplTest {
                 .setCreated(Instant.parse("2020-08-12T06:35:27.644Z"))
                 .setCmd("SafeEjectGPUAgent")
                 .build()),
-        processService.getProcesses(rConnection));
+        processService.getRserveProcesses(rConnection));
   }
 }

--- a/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
+++ b/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
@@ -68,7 +68,8 @@ class ProcessServiceImplTest {
                     entry("rss", 3411968.0),
                     entry("vms", 4938244096.0),
                     entry("created", 1597214127.64387),
-                    entry("cmd", "SafeEjectGPUAgent"))));
+                    entry("cmd", "SafeEjectGPUAgent"),
+                    entry("ports", ""))));
     when(rexpParser.parseDate(any())).thenCallRealMethod();
 
     assertEquals(

--- a/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
+++ b/r/src/test/java/org/molgenis/r/service/ProcessServiceImplTest.java
@@ -1,0 +1,107 @@
+package org.molgenis.r.service;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.r.REXPParser;
+import org.molgenis.r.model.RProcess;
+import org.molgenis.r.model.RProcess.Status;
+import org.rosuda.REngine.REXPMismatchException;
+import org.rosuda.REngine.REXPString;
+import org.rosuda.REngine.RList;
+import org.rosuda.REngine.Rserve.RConnection;
+import org.rosuda.REngine.Rserve.RserveException;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessServiceImplTest {
+  @Mock private REXPParser rexpParser;
+  @Mock private REXPString rexp;
+  @Mock private RList list;
+  @Mock private RConnection rConnection;
+
+  private ProcessService processService;
+
+  @BeforeEach
+  void before() {
+    processService = new ProcessServiceImpl(rexpParser);
+  }
+
+  @Test
+  void testGetProcesses() throws REXPMismatchException, RserveException {
+    when(rConnection.eval(anyString())).thenReturn(rexp);
+    when(rexp.asList()).thenReturn(list);
+    when(rexpParser.parseTibble(list))
+        .thenReturn(
+            List.of(
+                Map.ofEntries(
+                    entry("pid", 645),
+                    entry("ppid", 632),
+                    entry("name", "vpnkit-bridge"),
+                    entry("username", "root"),
+                    entry("status", "running"),
+                    entry("user", 3.475336003),
+                    entry("system", 3.907483292),
+                    entry("rss", 10137600.0),
+                    entry("vms", 4513603584.0),
+                    entry("created", 1597214141.41565),
+                    entry("cmd", "vpnkit-bridge --addr listen://1999 host"),
+                    entry("ports", "1234 5678")),
+                Map.ofEntries(
+                    entry("pid", 531),
+                    entry("ppid", 1),
+                    entry("name", "SafeEjectGPUAgent"),
+                    entry("username", "root"),
+                    entry("status", "running"),
+                    entry("user", 0.007282068),
+                    entry("system", 0.012664273),
+                    entry("rss", 3411968.0),
+                    entry("vms", 4938244096.0),
+                    entry("created", 1597214127.64387),
+                    entry("cmd", "SafeEjectGPUAgent"))));
+    when(rexpParser.parseDate(any())).thenCallRealMethod();
+
+    assertEquals(
+        List.of(
+            RProcess.builder()
+                .setPid(645)
+                .setPPid(632)
+                .setName("vpnkit-bridge")
+                .setCmd("vpnkit-bridge --addr listen://1999 host")
+                .setUsername("root")
+                .setStatus(Status.RUNNING)
+                .setUser(3.475336003)
+                .setSystem(3.907483292)
+                .setRss(10137600.0)
+                .setVms(4513603584.0)
+                .setCreated(Instant.parse("2020-08-12T06:35:41.416Z"))
+                .setCmd("vpnkit-bridge --addr listen://1999 host")
+                .setPorts(List.of(1234, 5678))
+                .build(),
+            RProcess.builder()
+                .setPid(531)
+                .setPPid(1)
+                .setName("SafeEjectGPUAgent")
+                .setCmd("SafeEjectGPUAgent")
+                .setUsername("root")
+                .setStatus(Status.RUNNING)
+                .setUser(0.007282068)
+                .setSystem(0.012664273)
+                .setRss(3411968.0)
+                .setVms(4938244096.0)
+                .setCreated(Instant.parse("2020-08-12T06:35:27.644Z"))
+                .setCmd("SafeEjectGPUAgent")
+                .build()),
+        processService.getProcesses(rConnection));
+  }
+}


### PR DESCRIPTION
Until the docker PR is merged you can use `registry.molgenis.org/molgenis/ds-60-rserver-363:PR-52`

TODO:
- [x] During load test I still see some NPE's because not all values returned are actually set.