### PR TITLE
fix: remove resources package as base package

### DIFF
--- a/armadillo/pom.xml
+++ b/armadillo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>armadillo-service</artifactId>
     <groupId>org.molgenis</groupId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.molgenis</groupId>
       <artifactId>r</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/armadillo/src/main/java/org/molgenis/armadillo/service/ArmadilloConnectionFactoryImpl.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/service/ArmadilloConnectionFactoryImpl.java
@@ -27,7 +27,6 @@ public class ArmadilloConnectionFactoryImpl implements ArmadilloConnectionFactor
     try {
       RConnection connection = rConnectionFactory.createConnection();
       setDataShieldOptions(connection);
-      loadResourcerPackage(connection);
       return connection;
     } catch (RserveException cause) {
       throw new ConnectionCreationFailedException(cause);
@@ -38,9 +37,5 @@ public class ArmadilloConnectionFactoryImpl implements ArmadilloConnectionFactor
     for (Entry<String, String> option : dataShieldOptions.getValue().entrySet()) {
       con.eval(format("base::options(%s = %s)", option.getKey(), option.getValue()));
     }
-  }
-
-  private void loadResourcerPackage(RConnection con) throws RserveException {
-    con.eval("library(resourcer)");
   }
 }

--- a/armadillo/src/main/resources/application.yml
+++ b/armadillo/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 datashield:
   whitelist:
     - dsBase
-    - resourcer
 
 springdoc:
   swagger-ui:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,9 +22,9 @@ services:
       RSERVE_HOST: rserver
       LOGGING_CONFIG: 'classpath:logback-file.xml'
       AUDIT_LOG_PATH: '/app/logs/audit.log'
-      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: 'https://auth.molgenis.org'
-      SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID: 'b396233b-cdb2-449e-ac5c-a0d28b38f791'
-    # DATASHIELD_WHITELIST: dsBase,resourcer,dsDanger
+    #  SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: 'https://auth.molgenis.org'
+    #  SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID: 'b396233b-cdb2-449e-ac5c-a0d28b38f791'
+    #  DATASHIELD_WHITELIST: dsBase,resourcer,dsDanger
     ports:
       - 8080:8080
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       RSERVE_HOST: rserver
       LOGGING_CONFIG: 'classpath:logback-file.xml'
       AUDIT_LOG_PATH: '/app/logs/audit.log'
-    # SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: 'https://auth.molgenis.org'
-    # SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID: 'b396233b-cdb2-449e-ac5c-a0d28b38f791'
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: 'https://auth.molgenis.org'
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID: 'b396233b-cdb2-449e-ac5c-a0d28b38f791'
     # DATASHIELD_WHITELIST: dsBase,resourcer,dsDanger
     ports:
       - 8080:8080
@@ -31,7 +31,7 @@ services:
       - ${PWD}/logs/:/app/logs
   rserver:
     # Use predefined production image:
-    image: molgenis/rserver:latest
+    image: sido/rserver:jfrog
     # or, if you want to customize the RServe installation,
     # build custom image using Dockerfile:
     # build: ./rserver

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,11 +30,8 @@ services:
     volumes:
       - ${PWD}/logs/:/app/logs
   rserver:
-    # Use predefined production image:
-    image: sido/rserver:jfrog
-    # or, if you want to customize the RServe installation,
-    # build custom image using Dockerfile:
-    # build: ./rserver
+    # to build your own rserver image please check: https://github.com/datashield/docker-armadillo-rserver-base
+    image: datashield/armadillo-rserver:1.0.3
     environment:
       DEBUG: "FALSE"
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ${PWD}/logs/:/app/logs
   rserver:
     # to build your own rserver image please check: https://github.com/datashield/docker-armadillo-rserver-base
-    image: datashield/armadillo-rserver:1.0.3
+    image: datashield/armadillo-rserver:1.0.4
     environment:
       DEBUG: "FALSE"
     ports:

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-docker-compose pull
-docker-compose build --no-cache --pull

--- a/docker/rserver/Dockerfile
+++ b/docker/rserver/Dockerfile
@@ -1,3 +1,0 @@
-FROM molgenis/rserver:latest
-RUN install2.r remotes
-RUN installGithub.r datashield/dsDanger@v6.1-dev datashield/dsBase@v6.1-dev

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
     <groupId>org.molgenis</groupId>
     <artifactId>armadillo-service</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>armadillo-service</name>
     <description>MOLGENIS Armadillo</description>
     <organization>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>armadillo-service</artifactId>
     <groupId>org.molgenis</groupId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Blocks on: https://github.com/datashield/docker-armadillo-rserver-base/pull/8.

The resourcer package needs to be uninstalled on the rserver image, before this version of Armadillo will run.