### PR TITLE
chore: bump spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.12</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.molgenis</groupId>


### PR DESCRIPTION
Bumps `spring-boot-starter-parent` to [2.5.12](https://github.com/spring-projects/spring-boot/releases/tag/v2.5.12), which contains an upgrade to Spring Framework 5.3.18 which contains a fix for [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965)