### PR TITLE
chore: migrate to java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,10 @@
 pipeline {
     agent {
         kubernetes {
-            inheritFrom 'molgenis-jdk11'
+            // the shared pod template defined in the Jenkins server config
+            inheritFrom 'shared'
+            // maven jdk17 pod template defined in this repository
+            yaml libraryResource("pod-templates/maven-jdk17.yaml")
         }
     }
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         kubernetes {
             // the shared pod template defined in the Jenkins server config
             inheritFrom 'shared'
-            // maven jdk17 pod template defined in this repository
+            // maven jdk17 pod template defined in molgenis/molgenis-jenkins-pipeline repository
             yaml libraryResource("pod-templates/maven-jdk17.yaml")
         }
     }

--- a/armadillo/pom.xml
+++ b/armadillo/pom.xml
@@ -13,8 +13,10 @@
   <properties>
     <org.obiba.datashield.ds4j-version>2.0.0</org.obiba.datashield.ds4j-version>
 
-    <dockerfile.repository>registry.hub.docker.com/molgenis/${project.artifactId}</dockerfile.repository>
+    <dockerfile.repository>registry.hub.docker.com/molgenis/${project.artifactId}
+    </dockerfile.repository>
     <dockerfile.tag>${project.version}</dockerfile.tag>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <repositories>
@@ -190,7 +192,8 @@
         </executions>
         <configuration>
           <from>
-            <!-- Current java 11 image.
+            <!-- Current java 17 image.
+            TODO choose correct image
             See https://console.cloud.google.com/gcr/images/distroless/GLOBAL/java?gcrImageListsize=30 -->
             <image>gcr.io/distroless/java@sha256:7fc091e8686df11f7bf0b7f67fd7da9862b2b9a3e49978d1184f0ff62cb673cc</image>
           </from>

--- a/armadillo/pom.xml
+++ b/armadillo/pom.xml
@@ -191,12 +191,6 @@
           </execution>
         </executions>
         <configuration>
-          <from>
-            <!-- Current java 17 image.
-            TODO choose correct image
-            See https://console.cloud.google.com/gcr/images/distroless/GLOBAL/java?gcrImageListsize=30 -->
-            <image>gcr.io/distroless/java@sha256:7fc091e8686df11f7bf0b7f67fd7da9862b2b9a3e49978d1184f0ff62cb673cc</image>
-          </from>
           <to>
             <image>${dockerfile.repository}:${dockerfile.tag}</image>
           </to>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <properties>
         <project.scm.id>github</project.scm.id>
 
-        <java.version>11</java.version>
+        <java.version>17</java.version>
 
         <!-- authentication for release scm plugin -->
         <project.scm.id>github</project.scm.id>


### PR DESCRIPTION
~TODO: figure out which image to get from https://console.cloud.google.com/gcr/images/distroless/GLOBAL/~

See: https://github.com/GoogleContainerTools/jib/blob/master/docs/default_base_image.md#migration-from-pre-30
See: https://stackoverflow.com/questions/67130671/why-jib-dropped-support-for-distroless-base-image

We will follow jib's recommendations and let jib choose the base image