### PR TITLE
Disable browser's basic-auth login popup

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
@@ -80,6 +80,7 @@ public class AuthConfig {
           .cors()
           .and()
           .httpBasic()
+          .authenticationEntryPoint(new NoPopupBasicAuthenticationEntryPoint())
           .realmName("Armadillo")
           .and()
           .logout()

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/NoPopupBasicAuthenticationEntryPoint.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/NoPopupBasicAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package org.molgenis.armadillo.security;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class NoPopupBasicAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+  }
+}


### PR DESCRIPTION
Haven't really thought about the consequences yet. Needs a full e2e test to see if datashield client still works with basic auth.