### PR TITLE
fix: redirect to login when unauthorized

### DIFF
--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -17,6 +17,8 @@ export async function get(url: string, auth: Auth | undefined = undefined) {
   const outcome = handleResponse(response);
   if (response.status === 204 || response.status === 500) {
     return outcome;
+  } else if (response.status === 403 || response.status === 401) {
+    return outcome;
   } else {
     return response.json();
   }

--- a/ui/src/helpers/errorProcessing.ts
+++ b/ui/src/helpers/errorProcessing.ts
@@ -1,0 +1,14 @@
+export function processErrorMessages(error: string, router: { push: (arg0: string) => Promise<any>; go: (arg0: number) => void; }) {
+  if (
+    error === "Unauthorized" ||
+    error.toString() ===
+      "ConnectionError: Full authentication is required to access this resource"
+  ) {
+    router.push("/login").then(() => {
+      router.go(0);
+    });
+    return error;
+  } else {
+    return `Could not load projects: ${error}.`;
+  }
+}

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -3,6 +3,7 @@ import Projects from "@/views/Projects.vue";
 import ProjectsExplorer from "@/views/ProjectsExplorer.vue";
 import Users from "@/views/Users.vue";
 import Profiles from "@/views/Profiles.vue";
+import Login from "@/views/Login.vue";
 
 const routes = [
     {
@@ -19,7 +20,11 @@ const routes = [
         name: "projects",
         component: Projects,
     },
-
+    {
+        path: "/login",
+        name: "login",
+        component: Login,
+    },
     {
         path: "/projects-explorer/:projectId/:folderId?/:fileId?",
         name: "projects-explorer",

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -109,6 +109,7 @@ import Badge from "@/components/Badge.vue";
 import {ProfilesData} from "@/types/types";
 import {useRouter} from "vue-router";
 import {isDuplicate} from "@/helpers/utils";
+import { processErrorMessages } from "@/helpers/errorProcessing";
 
 export default defineComponent({
   name: "Profiles",
@@ -130,11 +131,7 @@ export default defineComponent({
     });
     const loadProfiles = async () => {
       profiles.value = await getProfiles().catch((error: string) => {
-        if (error === "Unauthorized") {
-          router.push("/login");
-        } else {
-          errorMessage.value = error;
-        }
+        errorMessage.value = processErrorMessages(error, router);
         return [];
       });
     };

--- a/ui/src/views/Projects.vue
+++ b/ui/src/views/Projects.vue
@@ -102,6 +102,7 @@ import {defineComponent, onMounted, Ref, ref} from "vue";
 import {Project} from "@/types/api";
 import {ProjectsData} from "@/types/types";
 import {useRouter} from "vue-router";
+import { processErrorMessages } from "@/helpers/errorProcessing";
 
 export default defineComponent({
   name: "Projects",
@@ -124,11 +125,7 @@ export default defineComponent({
     });
     const loadProjects = async () => {
       projects.value = await getProjects().catch((error: string) => {
-        if (error === "Unauthorized") {
-          router.push("/login");
-        } else {
-          errorMessage.value = `Could not load projects: ${error}.`;
-        }
+        errorMessage.value = processErrorMessages(error, router);
         return [];
       });
     };

--- a/ui/src/views/ProjectsExplorer.vue
+++ b/ui/src/views/ProjectsExplorer.vue
@@ -168,6 +168,7 @@ import { StringArray, ProjectsExplorerData } from "@/types/types";
 import { useRoute, useRouter } from "vue-router";
 import FileUpload from "@/components/FileUpload.vue";
 import SimpleTable from "@/components/SimpleTable.vue";
+import { processErrorMessages } from "@/helpers/errorProcessing";
 
 export default defineComponent({
   name: "ProjectsExplorer",
@@ -220,11 +221,7 @@ export default defineComponent({
         idParam = route.params.projectId as string;
       }
       project.value = await getProject(idParam).catch((error: string) => {
-        if (error === "Unauthorized") {
-          router.push("/login");
-        } else {
-          errorMessage.value = error;
-        }
+        errorMessage.value = processErrorMessages(error, router);
         return [];
       });
       projectId.value = idParam;

--- a/ui/src/views/Users.vue
+++ b/ui/src/views/Users.vue
@@ -103,6 +103,7 @@ import {defineComponent, onMounted, Ref, ref} from "vue";
 import {User, UserStringKey} from "@/types/api";
 import {UsersData} from "@/types/types";
 import {useRouter} from "vue-router";
+import { processErrorMessages } from "@/helpers/errorProcessing";
 
 export default defineComponent({
   name: "Users",
@@ -125,11 +126,7 @@ export default defineComponent({
     });
     const loadUsers = async () => {
       users.value = await getUsers().catch((error: string) => {
-        if (error === "Unauthorized") {
-          router.push("/login");
-        } else {
-          errorMessage.value = `Could not load users: ${error}.`;
-        }
+        errorMessage.value = processErrorMessages(error, router);
         return [];
       });
     };


### PR DESCRIPTION
return complete object instead of json when 401 or 403 and when unauthorized error presented, redirect and refresh (separate function)

closes #309

To test: 
1) Run in dev mode using `yarn dev`
2) login on localhost:8080
3) go to localhost:8081
4) logout on 8080
5)  click on a tab in 8081
should redirect to login instead of giving cryptic error now. 