### PR TITLE
fix(navbar): remove api link

### DIFF
--- a/ui/src/components/Navbar.vue
+++ b/ui/src/components/Navbar.vue
@@ -8,7 +8,7 @@
           width="35"
           class="d-inline-block me-2"
         />
-        Armadillo portal (<a href="/swagger-ui/index.html">api</a>)
+        Armadillo portal
       </a>
       <form class="d-flex mt-1">
         <span class="navbar-text p-2" v-show="username"


### PR DESCRIPTION
since swagger is not available in production mode anyways (only dev), in dev mode enter swagger via /swagger-ui/index.html

fix #321