### PR TITLE
fix(profiles): check if status is online instead of text

### DIFF
--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -56,7 +56,7 @@
               :disabled="loading"
               :text="statusMapping[objectProps.data.status].text"
               @click.prevent="
-                statusMapping[objectProps.data.status].text === 'ONLINE'
+                statusMapping[objectProps.data.status].status === 'ONLINE'
                   ? stopProfile(objectProps.row.name)
                   : startProfile(objectProps.row.name)
               "


### PR DESCRIPTION
text actually is "stop", not "online", so the stopProfile would never be called

fix #323