### PR TITLE
fix(projects): dont refresh new project on edit project

### DIFF
--- a/ui/src/views/Projects.vue
+++ b/ui/src/views/Projects.vue
@@ -288,7 +288,6 @@ export default defineComponent({
       this.reloadProjects();
     },
     editProject(project: Project) {
-      this.clearNewProject();
       this.projectToEditIndex = this.getProjectIndex(project.name);
       this.projectToHighlightIndex = this.getProjectIndex(project.name);
       this.projectToEdit = project;


### PR DESCRIPTION
all buttons are disabled in edit mode, so we dont need to clear the new project

fix #355