### PR TITLE
fix: run list profiles and select profile as system

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
@@ -3,6 +3,7 @@ package org.molgenis.armadillo.command.impl;
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.molgenis.armadillo.controller.ArmadilloUtils.GLOBAL_ENV;
+import static org.molgenis.armadillo.security.RunAs.runAsSystem;
 import static org.molgenis.armadillo.storage.ArmadilloStorageService.PARQUET;
 import static org.molgenis.armadillo.storage.ArmadilloStorageService.RDS;
 
@@ -75,7 +76,7 @@ class CommandsImpl implements Commands {
 
   @Override
   public void selectProfile(String profileName) {
-    profileService.getByName(profileName);
+    runAsSystem(() -> profileService.getByName(profileName));
     armadilloSession.sessionCleanup();
     ActiveProfileNameAccessor.setActiveProfileName(profileName);
     armadilloSession = new ArmadilloSession(connectionFactory, processService);
@@ -83,7 +84,7 @@ class CommandsImpl implements Commands {
 
   @Override
   public List<String> listProfiles() {
-    return profileService.getAll().stream().map(ProfileConfig::getName).toList();
+    return runAsSystem(() -> profileService.getAll().stream().map(ProfileConfig::getName).toList());
   }
 
   @Override

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DataController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DataController.java
@@ -351,8 +351,11 @@ public class DataController {
   @PostMapping(value = "select-profile")
   @ResponseStatus(NO_CONTENT)
   public void selectProfile(Principal principal, @RequestBody @NotBlank String profileName) {
-    auditEventPublisher.audit(principal, SELECT_PROFILE, Map.of(SELECTED_PROFILE, profileName));
-    commands.selectProfile(profileName.trim());
+    auditEventPublisher.audit(
+        () -> commands.selectProfile(profileName.trim()),
+        principal,
+        SELECT_PROFILE,
+        Map.of(SELECTED_PROFILE, profileName));
   }
 
   @GetMapping(value = "profiles")

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/ProfileScopeConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/ProfileScopeConfig.java
@@ -2,6 +2,7 @@ package org.molgenis.armadillo.profile;
 
 import static java.lang.String.format;
 import static org.molgenis.armadillo.profile.ActiveProfileNameAccessor.getActiveProfileName;
+import static org.molgenis.armadillo.security.RunAs.runAsSystem;
 
 import org.molgenis.armadillo.exceptions.UnknownProfileException;
 import org.molgenis.armadillo.metadata.ProfileConfig;
@@ -20,7 +21,7 @@ public class ProfileScopeConfig {
   public ProfileConfig profileConfig(ProfileService profileService) {
     var activeProfileName = getActiveProfileName();
     try {
-      return profileService.getByName(activeProfileName);
+      return runAsSystem(() -> profileService.getByName(activeProfileName));
     } catch (UnknownProfileException e) {
       throw new IllegalStateException(
           format("Missing profile configuration for active profile '%s'.", activeProfileName));


### PR DESCRIPTION
elevate permissions for regular users when selecting/viewing profile(s)

fixes #385
fixes #405

Code to test #385:
``` r
library(DSI)
library(dsBaseClient)
library(DSMolgenisArmadillo)
armadillo_url <- "http://localhost:8080/"

token <- armadillo.get_token(armadillo_url)

builder <- DSI::newDSLoginBuilder()
builder$append(server = "armadillo",
               url = armadillo_url,
               token = token,
               table = "cohort1/2_1-core-1_0/nonrep",
               driver = "ArmadilloDriver")
logindata <- builder$build()
conns <- datashield.login(logins = logindata, symbol = "core_nonrep", variables = c("coh_country"), assign = TRUE)
```
Code to test #405:
``` r
library('MolgenisArmadillo')
library(DSI)
library(dsBaseClient)
library(DSMolgenisArmadillo)

armadillo_url <- "http://localhost:8080/"
token <- armadillo.get_token(armadillo_url)
con <- dsConnect(
  drv = armadillo(),
  name = "armadillo",
  token = token,
  url = armadillo_url,
  profile = "caravan-uniform",
  #profile = "default"
)
dsListPackages(con)
```