### PR TITLE
feat: add profile that only runs on basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ build/
 /docker/logs/
 /docker/data/
 **/audit.log
+
+application.yaml
+application.yml

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ java -jar molgenis-armadillo-3.*.jar \
 
 ## To run in development mode
 
-Using development profile, we can test agains auth.molgenis.org that is preconfigured in /armadillo/src/main/resources/application.yaml.
-However, you then need client-id and secret
+Using development profile, we can test against auth.molgenis.org that is preconfigured in /armadillo/src/main/resources/application.yaml.
+However, you then need a client-id and a secret
 
 ```
 java -jar molgenis-armadillo-3.*.jar \
@@ -75,8 +75,8 @@ java -jar molgenis-armadillo-3.*.jar \
 
 ## To run in production mode
 
-When running in production mode you should create your own application.yml file in your working directory. 
-An example can be found below, copy into application.yaml file.
+When running in production mode you should create your own `application.yml` file in your working directory. 
+An example can be found below, copy into `application.yml` file.
 
 `
 armadillo:
@@ -119,7 +119,7 @@ guide: https://github.com/molgenis/molgenis-service-armadillo/blob/master/script
 
 ## Docker images
 
-For testing, Armadillo 3 docker images are also available as docker image. These run in ' basic' profile.
+For testing, Armadillo 3 docker images are also available as docker image. These run in 'basic' profile.
 
 - release at https://hub.docker.com/r/molgenis/molgenis-armadillo
 - snapshot builds from pull requests at https://hub.docker.com/r/molgenis/molgenis-armadillo-snapshot

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ java -jar molgenis-armadillo-3.*.jar \
 ## To run in development mode
 
 Using development profile, we can test agains auth.molgenis.org that is preconfigured in /armadillo/src/main/resources/application.yaml.
-However, you then need client-id and secret.
+However, you then need client-id and secret
 
 ```
 java -jar molgenis-armadillo-3.*.jar \
@@ -70,6 +70,8 @@ java -jar molgenis-armadillo-3.*.jar \
 -Dspring.security.oauth2.client.registration.molgenis.client-id=xxx 
 -Dspring.security.oauth2.client.registration.molgenis.client-secret=xxx 
 ```
+
+> note you can also use these -D options also in IntelliJ for development, which is better practice then editing the file that might be accidentally committed
 
 ## To run in production mode
 

--- a/README.md
+++ b/README.md
@@ -47,31 +47,77 @@ Armadillo 3 can be installed on any flavor of linux OS or modern Unix-based Mac 
 * Java 17 JRE or JDK
 * Docker (for profiles)
 
-To spin up your own server on a laptop, you first need
-the [application.yml](https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/conf/application-local.yml)
-and edit for your needs. Then you can run:
+
+## To run using basic auth (only for testing!)
+
+Armadillo assumes that you will use OIDC for user/password management, ideally linked to an identity provider such as [LS login](https://lifescience-ri.eu/ls-login/).
+However, for most minimal testing you can run uses only basic auth and with one account with username/password 'admin'/'admin'. 
+Note that the 'oauth2' sign in option then is not functional.
+
+`
+java -jar molgenis-armadillo-3.*.jar \
+-Dspring.profiles.active=basic
+`
+
+## To run in development mode
+
+Using development profile, we can test agains auth.molgenis.org that is preconfigured in /armadillo/src/main/resources/application.yaml.
+However, you then need client-id and secret.
 
 ```
-export SPRING_PROFILES_ACTIVE=<your profile>
-export SPRING_CONFIG_LOCATION=<location to>/application-local.yml
-java -jar molgenis-armadillo-3.*.jar
+java -jar molgenis-armadillo-3.*.jar \
+-Dspring.profiles.active=development
+-Dspring.security.oauth2.client.registration.molgenis.client-id=xxx 
+-Dspring.security.oauth2.client.registration.molgenis.client-secret=xxx 
 ```
 
-Or using development mode
+## To run in production mode
 
-```
-export SPRING_PROFILES_ACTIVE=development
-java -jar molgenis-armadillo-3.*.jar
-```
+When running in production mode you should create your own application.yml file in your working directory. 
+An example can be found below, copy into application.yaml file.
 
-## Systemd Service
+`
+armadillo:
+  oidc-permission-enabled: false
+  docker-management-enabled: true
+  oidc-admin-user: <your OIDC email>
+spring:
+  security:
+    user:
+      name: admin
+      password: <your admin password for basic auth default user>
+    oauth2:
+      client:
+        registration:
+            molgenis:
+                client-id: <your client id>
+                client-secret: <your client secret>
+        provider:
+          molgenis:
+            issuer-uri: 'https://auth.molgenis.org'
+      resourceserver:
+        jwt:
+          issuer-uri: 'https://auth.molgenis.org'
+        opaquetoken:
+          client-id: 'b396233b-cdb2-449e-ac5c-a0d28b38f791'
+`
+> Note: If don't want to configure an oauth2 client for any reason, just remove the `oauth2` section.
+
+And then you can run:
+
+`
+java -jar molgenis-armadillo-3.*.jar \
+-Dspring.profiles.active=myprofile
+`
+
+## Run as =systemd Service
 
 Armadillo 3 is tested on latest Ubuntu-LTS based servers. To run armadillo 3 as service please follow this
 guide: https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/install/README.md
 
 ## Docker images
 
-For testing, Armadillo 3 docker images are also available as docker image. These run in 'development' profile.
+For testing, Armadillo 3 docker images are also available as docker image. These run in ' basic' profile.
 
 - release at https://hub.docker.com/r/molgenis/molgenis-armadillo
 - snapshot builds from pull requests at https://hub.docker.com/r/molgenis/molgenis-armadillo-snapshot
@@ -132,16 +178,6 @@ For local storage, you don't need to do anything. Data is automatically stored i
 in `application.yml` by changing the `storage.root-dir`
 setting.
 
-If you want to use MinIO as storage (including the test data), do the following:
-
-1. Start the container with `docker-compose --profile minio up`
-2. In your browser, go to `http://localhost:9090`
-3. Log in with _molgenis_ / _molgenis_
-4. Add a bucket `shared-lifecyle`
-5. Copy the folders in `data/shared-lifecycle` in this repository to the bucket
-6. In `application.yml`, uncomment the `minio` section.
-7. Now Armadillo will automatically connect to MinIO at startup.
-
 > **_Note_**: When you run Armadillo locally for the first time, the `lifecycle` project has not been
 > added to the system metadata yet. To add it automatically, see [Application properties](#application-properties).
 > Or you can add it manually:
@@ -150,35 +186,3 @@ If you want to use MinIO as storage (including the test data), do the following:
 > - Add the project `lifecycle`
 >
 > Now you're all set!
-
-### Application properties
-
-You can configure the application in `application.yml`. During development however, it is more convenient to override these settings in a local .yml file that
-you do not commit to git. Here's how to set that up:
-
-- Next to `application.yml`, create a file `application-local.yml` (this file is ignored by git)
-- Give it the following content:
-
-```
-armadillo:
-  oidc-permission-enabled: false
-  docker-management-enabled: true
-  oidc-admin-user: <your OIDC email>
-
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          molgenis:
-            client-id: <OIDC client ID>
-            client-secret: <OIDC client secret>
-```
-
-> Note: If can't configure an oauth2 client for any reason, just remove the `spring` section.
-
-- Now, in the Run Configuration for the DatashieldServiceApplication, add the following program argument:
-
-```--spring.config.additional-location=file:armadillo/src/main/resources/application-local.yml```
-
-Now the lifecycle test project (including its data) will work out of the box, and you will be able to log in with your OIDC account immediately.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ java -jar molgenis-armadillo-3.*.jar \
 -Dspring.profiles.active=myprofile
 `
 
-## Run as =systemd Service
+## Run as systemd Service
 
 Armadillo 3 is tested on latest Ubuntu-LTS based servers. To run armadillo 3 as service please follow this
 guide: https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/install/README.md

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/CurrentUserController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/CurrentUserController.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -31,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearerAuth")
 @SecurityRequirement(name = "JSESSIONID")
 @RequestMapping("my")
-@PreAuthorize("isAuthenticated()")
 public class CurrentUserController {
 
   private final OAuth2AuthorizedClientService clientService;

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/AuthInfoContributor.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/AuthInfoContributor.java
@@ -19,6 +19,8 @@ public class AuthInfoContributor implements InfoContributor {
 
   @Override
   public void contribute(Builder builder) {
-    builder.withDetail("auth", Map.of("clientId", clientId, "issuerUri", issuerUri));
+    if (clientId != null && issuerUri != null) {
+      builder.withDetail("auth", Map.of("clientId", clientId, "issuerUri", issuerUri));
+    }
   }
 }

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
@@ -36,7 +36,7 @@ import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-@Profile("!test")
+@Profile({"!test", "!basic"})
 @Import(UserDetailsServiceAutoConfiguration.class)
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @EnableWebSecurity
@@ -49,7 +49,41 @@ public class AuthConfig {
 
   @Configuration
   @EnableWebSecurity
-  @Profile({"!test"})
+  @Profile("basic")
+  @Order(0)
+  public static class LocalConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http.authorizeRequests()
+          .antMatchers(
+              "/",
+              "/info",
+              "/index.html",
+              "/basic-login",
+              "/armadillo-logo.png",
+              "favicon.ico",
+              "/assets/**",
+              "/v3/**",
+              "/swagger-ui/**",
+              "/ui/**",
+              "/swagger-ui.html")
+          .permitAll()
+          .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class))
+          .permitAll()
+          .requestMatchers(toAnyEndpoint())
+          .authenticated()
+          .and()
+          .httpBasic()
+          .and()
+          .csrf()
+          .disable();
+    }
+  }
+
+  @Configuration
+  @EnableWebSecurity
+  @Profile({"!test", "!basic"})
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.molgenis.client-id")
   @Order(1)
   // check against JWT and basic auth. You can also sign in using 'oauth2'
   public static class JwtConfig extends WebSecurityConfigurerAdapter {
@@ -104,7 +138,7 @@ public class AuthConfig {
   @EnableWebSecurity
   @Order(2)
   @ConditionalOnProperty("spring.security.oauth2.client.registration.molgenis.client-id")
-  @Profile({"!test"})
+  @Profile({"!test", "!basic"})
   // otherwise we gonna offer sign in
   public static class Oauth2LoginConfig extends WebSecurityConfigurerAdapter {
     AccessService accessService;
@@ -152,7 +186,7 @@ public class AuthConfig {
   }
 
   /** Allow CORS requests, needed for swagger UI to work, if the development profile is active. */
-  @Profile("development")
+  @Profile({"development", "basic"})
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     return request -> ALLOW_CORS;

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/JwtDecoderConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/JwtDecoderConfig.java
@@ -22,8 +22,8 @@ public class JwtDecoderConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(JwtDecoderConfig.class);
 
-  @Value("${spring.profiles.active}")
-  private String activeProfile;
+  @Value("${spring.profiles.active:default}")
+  private String activeProfile = "default";
 
   @Bean
   public JwtDecoder jwtDecoder(OAuth2ResourceServerProperties properties) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/JwtDecoderConfigLocal.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/JwtDecoderConfigLocal.java
@@ -1,0 +1,23 @@
+package org.molgenis.armadillo.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.jwt.*;
+
+// in case of test there are no oidc then we will have dummy JWT
+@Configuration
+@Profile("basic")
+public class JwtDecoderConfigLocal {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JwtDecoderConfigLocal.class);
+
+  @Bean
+  public JwtDecoder jwtDecoder() {
+    return token -> {
+      throw new UnsupportedOperationException("JWT dummy configuration for 'test'");
+    };
+  }
+}

--- a/armadillo/src/main/resources/application.yml
+++ b/armadillo/src/main/resources/application.yml
@@ -58,6 +58,24 @@ audit:
 logging:
   config: classpath:logback-file.xml
 
+storage:
+  root-dir: data
+
+---
+# 'basic' profile is a configuration without oidc
+# you can only sign in using basicauth 'admin' 'admin'
+
+spring:
+  security:
+    user:
+      password: admin
+  config:
+    activate:
+      on-profile: basic
+
+storage:
+  root-dir: data
+
 ---
 spring:
   security:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
   armadillo:
     image: molgenis/molgenis-armadillo-snapshot:latest
     environment:
-      SPRING_PROFILES_ACTIVE: development
+      SPRING_PROFILES_ACTIVE: basic
+      # basic doesn't use OIDC
       LOGGING_CONFIG: 'classpath:logback-file.xml'
       AUDIT_LOG_PATH: '/app/logs/audit.log'
     #  SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: 'https://auth.molgenis.org'


### PR DESCRIPTION
motivation: useful for automated test.

You can run it using the option:

`java -jar molgenis-armadillo-3.*.jar -Dspring.profiles.active=basic`


Also, you can then run the script in datashield as listed in docker/test/test-local.R

Furthermore updated documentation explaining how best to create your own application.yml, or when developing how to set the secrets via -D options.

