### PR TITLE
feat: create resource file with token when calling resource 

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/command/Commands.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/command/Commands.java
@@ -22,7 +22,7 @@ public interface Commands {
 
   CompletableFuture<Void> loadTable(String symbol, String table, List<String> variables);
 
-  CompletableFuture<Void> loadResource(String symbol, String resource);
+  CompletableFuture<Void> loadResource(Principal principal, String symbol, String resource);
 
   CompletableFuture<Void> loadWorkspace(Principal principal, String id);
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/command/impl/CommandsImpl.java
@@ -166,7 +166,7 @@ class CommandsImpl implements Commands {
   }
 
   @Override
-  public CompletableFuture<Void> loadResource(String symbol, String resource) {
+  public CompletableFuture<Void> loadResource(Principal principal, String symbol, String resource) {
     int index = resource.indexOf('/');
     String project = resource.substring(0, index);
     String objectName = resource.substring(index + 1);
@@ -176,7 +176,11 @@ class CommandsImpl implements Commands {
           protected Void doWithConnection(RServerConnection connection) {
             InputStream inputStream = armadilloStorage.loadResource(project, objectName);
             rExecutorService.loadResource(
-                connection, new InputStreamResource(inputStream), resource + RDS, symbol);
+                principal,
+                connection,
+                new InputStreamResource(inputStream),
+                resource + RDS,
+                symbol);
             return null;
           }
         });

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DataController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DataController.java
@@ -223,7 +223,7 @@ public class DataController {
     }
     var result =
         auditEventPublisher.audit(
-            commands.loadResource(symbol, resource), principal, LOAD_RESOURCE, data);
+            commands.loadResource(principal, symbol, resource), principal, LOAD_RESOURCE, data);
     return async
         ? completedFuture(created(getLastCommandLocation()).body(null))
         : result

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -196,7 +196,7 @@ class CommandsImplTest {
     when(armadilloStorage.loadResource("gecko", "2_1-core-1_0/hpc-resource"))
         .thenReturn(inputStream);
 
-    commands.loadResource("core_nonrep", "gecko/2_1-core-1_0/hpc-resource").get();
+    commands.loadResource(principal, "core_nonrep", "gecko/2_1-core-1_0/hpc-resource").get();
 
     verify(rExecutorService)
         .loadResource(

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -200,6 +200,7 @@ class CommandsImplTest {
 
     verify(rExecutorService)
         .loadResource(
+            eq(principal),
             eq(rConnection),
             any(InputStreamResource.class),
             eq("gecko/2_1-core-1_0/hpc-resource.rds"),

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/DataControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/DataControllerTest.java
@@ -835,7 +835,7 @@ class DataControllerTest extends ArmadilloControllerTestBase {
   @WithMockUser(roles = "SU")
   void testLoadResource() throws Exception {
     when(armadilloStorage.resourceExists("gecko", "2_1-core-1_1/hpc-resource-1")).thenReturn(true);
-    when(commands.loadResource("hpc_res", "gecko/2_1-core-1_1/hpc-resource-1"))
+    when(commands.loadResource(principal, "hpc_res", "gecko/2_1-core-1_1/hpc-resource-1"))
         .thenReturn(completedFuture(null));
 
     mockMvc

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/DataControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/DataControllerTest.java
@@ -835,7 +835,8 @@ class DataControllerTest extends ArmadilloControllerTestBase {
   @WithMockUser(roles = "SU")
   void testLoadResource() throws Exception {
     when(armadilloStorage.resourceExists("gecko", "2_1-core-1_1/hpc-resource-1")).thenReturn(true);
-    when(commands.loadResource(principal, "hpc_res", "gecko/2_1-core-1_1/hpc-resource-1"))
+    when(commands.loadResource(
+            any(Principal.class), eq("hpc_res"), eq("gecko/2_1-core-1_1/hpc-resource-1")))
         .thenReturn(completedFuture(null));
 
     mockMvc

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -21,7 +21,10 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
 
     //other
     implementation 'commons-io:commons-io:2.11.0'

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -39,6 +39,7 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
     testImplementation 'org.springframework.security:spring-security-core'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
 
     //annotation
     annotationProcessor "com.google.auto.value:auto-value:1.10.1"

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 
     //other
     implementation 'commons-io:commons-io:2.11.0'

--- a/r/src/main/java/org/molgenis/r/service/RExecutorService.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorService.java
@@ -1,6 +1,7 @@
 package org.molgenis.r.service;
 
 import java.io.InputStream;
+import java.security.Principal;
 import java.util.List;
 import java.util.function.Consumer;
 import org.molgenis.r.RServerConnection;
@@ -23,6 +24,13 @@ public interface RExecutorService {
 
   void loadResource(
       RServerConnection connection, Resource resource, String filename, String symbol);
+
+  void loadResource(
+      Principal principal,
+      RServerConnection connection,
+      Resource resource,
+      String filename,
+      String symbol);
 
   void installPackage(RServerConnection connection, Resource packageResource, String name);
 }

--- a/r/src/main/java/org/molgenis/r/service/RExecutorService.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorService.java
@@ -23,9 +23,6 @@ public interface RExecutorService {
       List<String> variables);
 
   void loadResource(
-      RServerConnection connection, Resource resource, String filename, String symbol);
-
-  void loadResource(
       Principal principal,
       RServerConnection connection,
       Resource resource,

--- a/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
@@ -8,6 +8,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.Principal;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -22,6 +23,7 @@ import org.molgenis.r.exceptions.RExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -107,18 +109,53 @@ public class RExecutorServiceImpl implements RExecutorService {
 
   @Override
   public void loadResource(
-      RServerConnection connection, Resource resource, String filename, String symbol) {
+      RServerConnection connection, Resource resource, String filename, String symbol) {}
+
+  @Override
+  public void loadResource(
+      Principal principal,
+      RServerConnection connection,
+      Resource resource,
+      String filename,
+      String symbol) {
     LOGGER.debug("Load resource from file {} into {}", filename, symbol);
+
+    // data.put("secret", token.getToken().getTokenValue());
     String rFileName = filename.replace("/", "_");
     try {
-      copyFile(resource, rFileName, connection);
+      if (principal instanceof JwtAuthenticationToken token) {
+        execute(
+            format(
+                """
+                        resourcer::newResource(
+                                name = "GSE66351_1",
+                                url = "http://host.docker.internal:8080/storage/projects/omics/objects/test%sgse66351_1.rda",
+                                format = "ExpressionSet"
+                                secret = %s
+                        )""",
+                "%2F", token),
+            connection);
+      }
+      // copyFile(resource, rFileName, connection);
+      // WE CREATE A FILE THAT LOOKS LIKE A RESOURCE
+      // FIRST WE RUN IN R THE FOLLOWING
+      //      execute(    format(          """
+      //                  toFile(%s, newResource(
+      //                          name = "GSE66351_1",
+      //                          url =
+      // "http://host.docker.internal:8080/storage/projects/omics/objects/test%2Fgse66351_1.rda",
+      //                          format = "ExpressionSet"
+      //                          token =
+      //                  )))""",rFileName);
+      // execute(format("rds <- base::readRDS('%s')", rFileName), connection);
+      // copyFile(resource, rFileName, connection);
       execute(
           format(
               "is.null(base::assign('%s', value={resourcer::newResourceClient(base::readRDS('%s'))}))",
               symbol, rFileName),
           connection);
       execute(format("base::unlink('%s')", rFileName), connection);
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw new RExecutionException(e);
     }
   }

--- a/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
@@ -134,7 +134,7 @@ public class RExecutorServiceImpl implements RExecutorService {
                                 format = "ExpressionSet",
                                 secret = "%s"
                         )}))""",
-                symbol, "%2F", ((Jwt) token.getToken()).getTokenValue()),
+                "%2F", ((Jwt) token.getToken()).getTokenValue()),
             connection);
       }
       execute(


### PR DESCRIPTION
Work in progress. Doesn't work yet (creating the file in RExecutorServiceImpl.java#127 doesn't work yet). 
Prerequisites in armadillo:
1) Add the caravan-uniform profile in the armadillo ui:
name: uniform
image: datashield/armadillo-rserver_caravan-uniform:2.0.0
packages whitelist: dsOmics, dsBase, resourcer
2) Start the profile
3) Create project omics in the UI
4) Create folder test
5) Download the testfile: https://github.com/isglobal-brge/brge_data_large/blob/master/data/gse66351_1.rda
6) Upload it in your test folder (increase max file size in `application.yml`:
```spring:
  servlet:
    multipart:
      max-file-size: 500MB
      max-request-size: 500MB
```
)


R code (for testing):
Creating resources (make sure v1.4 of the resourcer is used, this shouldn't be needed when this feature is complete(?)):
```R
library(MolgenisArmadillo)
library(resourcer)
token <- armadillo.get_token("http://localhost:8080/")
resGSE1 <- resourcer::newResource(
  name = "GSE66351_1",
  url = "http://host.docker.internal:8080/storage/projects/omics/objects/test%2Fgse66351_1.rda",
  format = "ExpressionSet"
)
```

For testing the behaviour:
```R
library(DSMolgenisArmadillo)
library(dsBaseClient)

token <- armadillo.get_token("http://127.0.0.1:8080/")
builder <- DSI::newDSLoginBuilder()
builder$append(
  server = "local",
  #url = "http://localhost:8080/",
  url = "http://127.0.0.1:8080/",
  token = token,
  driver = "ArmadilloDriver",
  profile = "uniform",
  resource = "omics/ewas/GSE66351_1"
)

login_data <- builder$build()
# In the line below, the RDS file is opened to retrieve the URL to get the actual resource from
conns <- DSI::datashield.login(logins = login_data, assign = TRUE)

datashield.resources(conns = conns)
# Here again the RDS file is opened, URL is retrieved)
datashield.assign.resource(conns, resource="omics/ewas/GSE66351_1", symbol="eSet_0y_EUR")
ds.class('eSet_0y_EUR', datasources = conns)
# Here the actual resource URL is being read (which will fail == the actual problem we're trying to solve)
datashield.assign.expr(conns, symbol = "methy_0y_EUR",expr = quote(as.resource.object(eSet_0y_EUR)))
```