### PR TITLE
fix: retrieve filesize of resource from filepath

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/StorageController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/StorageController.java
@@ -37,7 +37,6 @@ import javax.validation.constraints.NotEmpty;
 import org.molgenis.armadillo.audit.AuditEventPublisher;
 import org.molgenis.armadillo.exceptions.FileProcessingException;
 import org.molgenis.armadillo.storage.ArmadilloStorageService;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
@@ -257,7 +256,7 @@ public class StorageController {
   @GetMapping(
       value = "/projects/{project}/objects/{object}",
       produces = {APPLICATION_OCTET_STREAM_VALUE})
-  public @ResponseBody ResponseEntity<ByteArrayResource> downloadObject(
+  public @ResponseBody ResponseEntity<InputStreamResource> downloadObject(
       Principal principal, @PathVariable String project, @PathVariable String object) {
     return auditor.audit(
         () -> getObject(project, object),
@@ -267,19 +266,21 @@ public class StorageController {
   }
 
   @PreAuthorize("hasAnyRole('ROLE_SU', 'ROLE_' + #project.toUpperCase() + '_RESEARCHER')")
-  private ResponseEntity<ByteArrayResource> getObject(String project, String object) {
+  private ResponseEntity<InputStreamResource> getObject(String project, String object) {
     var inputStream = storage.loadObject(project, object);
     var objectParts = object.split("/");
     var fileName = objectParts[objectParts.length - 1];
 
     try {
       InputStreamResource inputStreamResource = new InputStreamResource(inputStream);
-      long length = inputStream.available();
       ContentDisposition contentDisposition =
           ContentDisposition.attachment().filename(fileName).build();
+      var fileSize =
+          storage.getFileSizeIfObjectExists(
+              ArmadilloStorageService.SHARED_PREFIX + project, object);
       HttpHeaders httpHeaders = new HttpHeaders();
       httpHeaders.setContentDisposition(contentDisposition);
-      httpHeaders.setContentLength(length);
+      httpHeaders.setContentLength(fileSize);
       httpHeaders.setContentType(APPLICATION_OCTET_STREAM);
       return new ResponseEntity(inputStreamResource, httpHeaders, HttpStatus.OK);
     } catch (IOException e) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
@@ -6,7 +6,10 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -227,6 +230,11 @@ public class ArmadilloStorageService {
     if (!pattern.matcher(projectName).matches()) {
       throw new InvalidProjectNameException(projectName);
     }
+  }
+
+  public long getFileSizeIfObjectExists(String bucketName, String objectName) throws IOException {
+    Path filePath = storageService.getPathIfObjectExists(bucketName, objectName);
+    return Files.size(filePath);
   }
 
   @PreAuthorize("hasRole('ROLE_SU')")

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -168,7 +168,7 @@ public class LocalStorageService implements StorageService {
     }
   }
 
-  private Path getPathIfObjectExists(String bucketName, String objectName) {
+  public Path getPathIfObjectExists(String bucketName, String objectName) {
     Path bucketPath = Paths.get(rootDir, bucketName);
     if (!Files.exists(bucketPath)) {
       throw new StorageException(format("Bucket '%s' doesn't exist", bucketName));

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/MinioStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/MinioStorageService.java
@@ -22,6 +22,7 @@ import io.minio.errors.XmlParserException;
 import io.minio.messages.Bucket;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -230,5 +231,10 @@ class MinioStorageService implements StorageService {
         | XmlParserException e) {
       throw new StorageException(e);
     }
+  }
+
+  @Override
+  public Path getPathIfObjectExists(String bucketName, String objectName) {
+    return null;
   }
 }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
@@ -1,6 +1,7 @@
 package org.molgenis.armadillo.storage;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.MediaType;
@@ -24,4 +25,6 @@ public interface StorageService {
       String bucketName, String objectName, int rowLimit, int columnLimit);
 
   void delete(String bucketName, String objectName);
+
+  public Path getPathIfObjectExists(String bucketName, String objectName);
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/StorageControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/StorageControllerTest.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -387,7 +388,9 @@ class StorageControllerTest extends ArmadilloControllerTestBase {
   void downloadObject() throws Exception {
     var content = "content".getBytes();
     var inputStream = new ByteArrayInputStream(content);
+    Path mockPath = mock(Path.class);
     when(storage.loadObject("lifecycle", "test.parquet")).thenReturn(inputStream);
+    when(storage.getFileSizeIfObjectExists("shared-lifecycle", "test.parquet")).thenReturn(12345L);
 
     mockMvc
         .perform(get("/storage/projects/lifecycle/objects/test.parquet").session(session))


### PR DESCRIPTION
So that we don't run into the max size of a byte array to make sure we can use resources over 2.15GB

fixes #458