### PR TITLE
Feat: datashield seed UI column

### DIFF
--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -48,8 +48,10 @@ export type Profile = {
   port: number;
   packageWhitelist: StringArray;
   functionBlacklist: StringArray;
-  datashieldSeed: number;
-  options: Object;
+  datashieldSeed?: string;
+  options: {
+    "datashield.seed"?: string;
+  };
   container: {
     tags: StringArray;
     status: string;

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -48,9 +48,9 @@ export type Profile = {
   port: number;
   packageWhitelist: StringArray;
   functionBlacklist: StringArray;
-  datashieldSeed?: string;
+  datashieldSeed: string;
   options: {
-    "datashield.seed"?: string;
+    "datashield.seed": string;
   };
   container: {
     tags: StringArray;

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -48,6 +48,7 @@ export type Profile = {
   port: number;
   packageWhitelist: StringArray;
   functionBlacklist: StringArray;
+  datashieldSeed: number;
   options: Object;
   container: {
     tags: StringArray;

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -154,6 +154,11 @@ export default defineComponent({
       profiles.value = await getProfiles()
         .then((profiles) => {
           dockerManagementEnabled.value = "container" in profiles[0];
+          for (var profile in profiles) {
+            profiles[profile]["datashieldSeed"] =
+              profiles[profile].options["datashield.seed"];
+          }
+          console.log(profiles);
           return profiles;
         })
         .catch((error: string) => {
@@ -221,6 +226,7 @@ export default defineComponent({
         port: "string",
         packageWhitelist: "array",
         functionBlacklist: "array",
+        datashieldSeed: "string",
         options: "object",
       };
 
@@ -334,6 +340,7 @@ export default defineComponent({
         port: this.firstFreePort,
         packageWhitelist: ["dsBase"],
         functionBlacklist: [],
+        datashieldSeed: 0,
         options: {},
         container: { tags: [], status: "unknown" },
       });


### PR DESCRIPTION
- Extracted Datashield Seed from Options into seperate Profiles UI column.
- Hidden datashield.seed from Options UI column.
- (To set a datashield.seed or to set a different datashield.seed, use the options column. Changing or setting a datashield seed throught the "Datashield Seed" column is disabled.)
- Added functionality to automatically asign an unused datashield seed when a new profile is created from the UI.
- 