### PR TITLE
Feat/preview file details

### DIFF
--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -173,3 +173,7 @@ export async function authenticate(auth: Auth) {
   });
   return handleResponse(response);
 }
+
+export async function getFileDetails(project: string, object: string) {
+  return get(`/storage/projects/${project}/objects/${object}/info`);
+}

--- a/ui/src/components/SimpleTable.vue
+++ b/ui/src/components/SimpleTable.vue
@@ -9,7 +9,8 @@
         <th scope="col" v-for="key in tableHeader" :key="key">
           {{ key }}
         </th>
-        <th scope="col">...</th>
+        <!-- Not required if there are not at least 11 columns -->
+        <th v-if="nCols > 10" scope="col">...</th>
       </tr>
     </thead>
     <tbody class="table-group-divider">
@@ -19,13 +20,16 @@
         <td v-for="(value, key) in row" :key="key">
           {{ value }}
         </td>
-        <!-- if index is 0 -->
-        <!-- <td rowspan="10" v-if="index === 0" class="fst-italic">+ 102</td> -->
-        <td rowspan="10" v-if="index === 0" class="fst-italic">+ more</td>
+        <!-- Will display the "+ x more" if 11 or more columns are present, else hides the column entirely -->
+        <td rowspan="10" v-if="index === 0 && nCols > 10" class="fst-italic">
+          {{ `+ ${nCols - 10} more` }}
+        </td>
       </tr>
       <tr class="text-end fst-italic">
-        <!-- <td colspan="11">1470 more rows</td> -->
-        <td colspan="11">+ more rows</td>
+        <!-- Same goes for rows, only display when there are at least 11 or more rows -->
+        <td colspan="11" v-if="nRows > 10">
+          {{ `+ ${nRows - 10} more rows` }}
+        </td>
       </tr>
     </tbody>
   </table>

--- a/ui/src/components/SimpleTable.vue
+++ b/ui/src/components/SimpleTable.vue
@@ -47,6 +47,14 @@ export default defineComponent({
       type: Number,
       required: true,
     },
+    nRows: {
+      type: Number,
+      required: true,
+    },
+    nCols: {
+      type: Number,
+      required: true,
+    },
   },
   computed: {
     maxNumberCharacters() {

--- a/ui/src/types/types.d.ts
+++ b/ui/src/types/types.d.ts
@@ -38,6 +38,9 @@ export type ProjectsExplorerData = {
   loading: boolean;
   successMessage: string;
   filePreview: Array<any>;
+  fileSize: string;
+  dataSizeRows: number;
+  dataSizeColumns: number;
   createNewFolder: boolean;
   loading_preview: boolean;
   newFolder: string;

--- a/ui/src/views/ProjectsExplorer.vue
+++ b/ui/src/views/ProjectsExplorer.vue
@@ -135,7 +135,7 @@
                 Preview:
                 <!-- {{ `${selectedFile.replace(".parquet", "")} (108x1500)` }} -->
                 {{ `${selectedFile.replace(".parquet", "")}` }} ({{
-                  `${dataSizeColumns}x${dataSizeRows}`
+                  `${dataSizeRows}x${dataSizeColumns}`
                 }})
               </div>
               <SimpleTable

--- a/ui/src/views/ProjectsExplorer.vue
+++ b/ui/src/views/ProjectsExplorer.vue
@@ -127,18 +127,22 @@
             ></LoadingSpinner>
             <div v-if="isNonTableType(selectedFile)">
               <div class="fst-italic">
-                No preview available for: {{ selectedFile }}
+                No preview available for: {{ selectedFile }} ({{ fileSize }})
               </div>
             </div>
             <div v-else-if="!loading_preview && !askIfPreviewIsEmpty()">
               <div class="text-end fst-italic">
                 Preview:
                 <!-- {{ `${selectedFile.replace(".parquet", "")} (108x1500)` }} -->
-                {{ `${selectedFile.replace(".parquet", "")}` }}
+                {{ `${selectedFile.replace(".parquet", "")}` }} ({{
+                  `${dataSizeColumns}x${dataSizeRows}`
+                }})
               </div>
               <SimpleTable
                 :data="filePreview"
                 :maxWidth="previewContainerWidth"
+                :n-rows="dataSizeRows"
+                :n-cols="dataSizeColumns"
               ></SimpleTable>
             </div>
             <div v-else-if="!loading_preview && askIfPreviewIsEmpty()">
@@ -159,7 +163,12 @@ import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
 import ListGroup from "@/components/ListGroup.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import FeedbackMessage from "@/components/FeedbackMessage.vue";
-import { getProject, deleteObject, previewObject } from "@/api/api";
+import {
+  getProject,
+  deleteObject,
+  previewObject,
+  getFileDetails,
+} from "@/api/api";
 import { isEmptyObject, sortAlphabetically } from "@/helpers/utils";
 import { defineComponent, onMounted, Ref, ref, watch } from "vue";
 import { StringArray, ProjectsExplorerData } from "@/types/types";
@@ -255,6 +264,9 @@ export default defineComponent({
       loading_preview: false,
       successMessage: "",
       filePreview: [{}],
+      fileSize: "",
+      dataSizeRows: 0,
+      dataSizeColumns: 0,
       createNewFolder: false,
       newFolder: "",
       projectContent: {},
@@ -279,6 +291,28 @@ export default defineComponent({
             this.errorMessage = `Cannot load preview for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
             this.clearFilePreview();
             this.loading_preview = false;
+          });
+        getFileDetails(
+          this.projectId,
+          `${this.selectedFolder}%2F${this.selectedFile}`
+        )
+          .then((data) => {
+            this.dataSizeRows = data["rows"];
+            this.dataSizeColumns = data["columns"];
+          })
+          .catch((error) => {
+            this.errorMessage = `Cannot load details for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
+          });
+      } else {
+        getFileDetails(
+          this.projectId,
+          `${this.selectedFolder}%2F${this.selectedFile}`
+        )
+          .then((data) => {
+            this.fileSize = data["size"];
+          })
+          .catch((error) => {
+            this.errorMessage = `Cannot load details for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
           });
       }
     },

--- a/ui/src/views/ProjectsExplorer.vue
+++ b/ui/src/views/ProjectsExplorer.vue
@@ -292,29 +292,19 @@ export default defineComponent({
             this.clearFilePreview();
             this.loading_preview = false;
           });
-        getFileDetails(
-          this.projectId,
-          `${this.selectedFolder}%2F${this.selectedFile}`
-        )
-          .then((data) => {
-            this.dataSizeRows = data["rows"];
-            this.dataSizeColumns = data["columns"];
-          })
-          .catch((error) => {
-            this.errorMessage = `Cannot load details for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
-          });
-      } else {
-        getFileDetails(
-          this.projectId,
-          `${this.selectedFolder}%2F${this.selectedFile}`
-        )
-          .then((data) => {
-            this.fileSize = data["size"];
-          })
-          .catch((error) => {
-            this.errorMessage = `Cannot load details for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
-          });
       }
+      getFileDetails(
+        this.projectId,
+        `${this.selectedFolder}%2F${this.selectedFile}`
+      )
+        .then((data) => {
+          this.fileSize = data["size"];
+          this.dataSizeRows = data["rows"];
+          this.dataSizeColumns = data["columns"];
+        })
+        .catch((error) => {
+          this.errorMessage = `Cannot load details for [${this.selectedFolder}/${this.selectedFile}] of project [${this.projectId}]. Because: ${error}.`;
+        });
     },
     project() {
       this.setProjectContent();


### PR DESCRIPTION
https://trello.com/c/T5lWuzN9/1093-m10331-as-armadillo-datamanagers-i-want-to-be-able-to-preview-file-information

- Added GET API call for file information
- Added dtypes for new variables of `ProjectsExplorerData` (`fileSize`, `dataSizeRows`, `dataSizeColumns`)
- Implemented method to get file details into the watch of selectedFile() to set `fileSize`, `dataSizeRows` and `dataSizeColumns`
- Added required nRows and nCols props to SimpleTable.vue
- Implemented v-if statements to make smaller SimpleTables cleaner if not enough columns/rows are present to show "+ x more" column/row.
- Added filesize to any non-parquet file in file preview
- Added rows x columns to any parquet file in file preview