### PR TITLE
Add isRock variable to profiles

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -125,6 +125,7 @@ public class DevelopmentController {
         ProfileConfig.create(
             currentConfig.getName(),
             currentConfig.getImage(),
+            currentConfig.getIsRock(),
             currentConfig.getHost(),
             currentConfig.getPort(),
             whitelist,

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
@@ -18,6 +18,8 @@ public abstract class ProfileResponse {
   @Nullable // only required when docker enabled
   public abstract String getImage();
 
+  public abstract boolean getIsRock();
+
   public abstract String getHost();
 
   public abstract Integer getPort();
@@ -36,6 +38,7 @@ public abstract class ProfileResponse {
     return new AutoValue_ProfileResponse(
         profileConfig.getName(),
         profileConfig.getImage(),
+        profileConfig.getIsRock(),
         profileConfig.getHost(),
         profileConfig.getPort(),
         profileConfig.getPackageWhitelist(),

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
@@ -12,6 +12,8 @@ import java.util.Set;
 public class InitialProfileConfig {
   private String name;
   private String image;
+  private boolean isRock;
+
   private String host;
   private int port;
   private Set<String> packageWhitelist;
@@ -20,7 +22,7 @@ public class InitialProfileConfig {
 
   public ProfileConfig toProfileConfig() {
     return ProfileConfig.create(
-        name, image, host, port, packageWhitelist, functionBlacklist, options);
+        name, image, isRock, host, port, packageWhitelist, functionBlacklist, options);
   }
 
   public void setName(String name) {
@@ -29,6 +31,10 @@ public class InitialProfileConfig {
 
   public void setImage(String image) {
     this.image = image;
+  }
+
+  public void setIsRock(boolean isRock) {
+    this.isRock = isRock;
   }
 
   public void setHost(String host) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
@@ -24,6 +24,9 @@ public abstract class ProfileConfig {
   @Nullable // only required when docker enabled
   public abstract String getImage();
 
+  @JsonProperty("isRock")
+  public abstract boolean getIsRock();
+
   @JsonProperty("host")
   @Nullable // defaults to localhost
   @NotEmpty
@@ -46,6 +49,7 @@ public abstract class ProfileConfig {
   public static ProfileConfig create(
       @JsonProperty("name") String newName,
       @JsonProperty("image") String newImage,
+      @JsonProperty("isRock") boolean newIsRock,
       @JsonProperty("host") String newHost,
       @JsonProperty("port") Integer newPort,
       @JsonProperty("packageWhitelist") Set<String> newPackageWhitelist,
@@ -54,6 +58,7 @@ public abstract class ProfileConfig {
     return new AutoValue_ProfileConfig(
         newName,
         newImage,
+        newIsRock,
         newHost != null ? newHost : "localhost",
         newPort,
         newPackageWhitelist,
@@ -66,6 +71,7 @@ public abstract class ProfileConfig {
     return create(
         "default",
         "datashield/armadillo-rserver",
+        true,
         "localhost",
         6311,
         Set.of("dsBase"),

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -60,6 +60,7 @@ public class ProfileService {
             ProfileConfig.create(
                 profileName,
                 profileConfig.getImage(),
+                profileConfig.getIsRock(),
                 profileConfig.getHost(),
                 profileConfig.getPort(),
                 profileConfig.getPackageWhitelist(),

--- a/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
@@ -40,7 +40,7 @@ class DataShieldOptionsImplTest {
         ImmutableMap.of("a", "overrideA", "c", "overrideC");
     ProfileConfig profileConfig =
         ProfileConfig.create(
-            "dummy", "dummy", "localhost", 6311, Set.of(), emptySet(), configOptions);
+            "dummy", "dummy", false, "localhost", 6311, Set.of(), emptySet(), configOptions);
     options = new DataShieldOptionsImpl(profileConfig, packageService);
     ImmutableMap<String, String> packageOptions = ImmutableMap.of("a", "defaultA", "b", "defaultB");
     doReturn(rConnection).when(rConnectionFactory).tryCreateConnection();

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -240,7 +240,8 @@ class CommandsImplTest {
   void testSelectProfileWritesToSession() {
     RequestContextHolder.setRequestAttributes(attrs);
     ProfileConfig profileConfig =
-        ProfileConfig.create("exposome", "dummy", "localhost", 6311, Set.of(), Set.of(), Map.of());
+        ProfileConfig.create(
+            "exposome", "dummy", false, "localhost", 6311, Set.of(), Set.of(), Map.of());
     when(profileService.getByName("exposome")).thenReturn(profileConfig);
     commands.selectProfile("exposome");
     verify(attrs).setAttribute("profile", "exposome", SCOPE_SESSION);

--- a/armadillo/src/test/java/org/molgenis/armadillo/config/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/config/DockerServiceTest.java
@@ -146,6 +146,7 @@ class DockerServiceTest {
         ProfileConfig.create(
             "omics",
             "datashield/armadillo-rserver-omics",
+            false,
             "localhost",
             6312,
             Set.of("dsBase", "dsOmics"),

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -63,6 +63,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
             ProfileConfig.create(
                 "default",
                 "datashield/armadillo-rserver:6.2.0",
+                false,
                 "localhost",
                 6311,
                 Set.of("dsBase"),
@@ -75,6 +76,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
             ProfileConfig.create(
                 "omics",
                 "datashield/armadillo-rserver-omics",
+                false,
                 "localhost",
                 6312,
                 Set.of("dsBase", "dsOmics"),
@@ -113,6 +115,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
         ProfileConfig.create(
             "dummy",
             "dummy/armadillo:2.0.0",
+            false,
             "localhost",
             6312,
             Set.of("dsBase"),

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
@@ -24,7 +24,14 @@ class ProfileServiceTest {
     var profilesMetadata = ProfilesMetadata.create();
     var defaultProfile =
         ProfileConfig.create(
-            "default", "test", "localhost", 1234, new HashSet<>(), Set.of(), new HashMap<>());
+            "default",
+            "test",
+            false,
+            "localhost",
+            1234,
+            new HashSet<>(),
+            Set.of(),
+            new HashMap<>());
     profilesMetadata.getProfiles().put("default", defaultProfile);
     var profilesLoader = new DummyProfilesLoader(profilesMetadata);
     var profileService = new ProfileService(profilesLoader, initialProfileConfigs, profileScope);

--- a/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
+++ b/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
@@ -1,5 +1,7 @@
 package org.molgenis.r;
 
+import java.io.IOException;
+import java.net.*;
 import org.molgenis.r.config.EnvironmentConfigProps;
 import org.molgenis.r.rock.RockConnectionFactory;
 import org.molgenis.r.rserve.RserveConnectionFactory;
@@ -15,10 +17,55 @@ public class RServerConnectionFactory implements RConnectionFactory {
     this.environment = environment;
   }
 
+  int doHead(String uri) {
+    URL url;
+    try {
+      url = new URL(uri);
+      HttpURLConnection connection;
+      try {
+        connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("HEAD");
+        connection.getContentLength();
+        // -1 for rserve
+        // 200 for rock
+        return connection.getResponseCode();
+      } catch (ConnectException e) {
+        // down
+        return -99;
+      } catch (SocketException e) {
+        // Server not ready
+        return -2;
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
+    }
+    return -3;
+  }
+
   @Override
   public RServerConnection tryCreateConnection() {
+    logger.warn("================ IsRock testing ====================");
+    String url = "http://" + environment.getHost() + ":" + environment.getPort();
+    int status = doHead(url);
+    if (status == -99) {
+      // server down
+      logger.warn("Container is down");
+    } else if (status == -2) {
+      logger.warn("Container service not ready");
+    }
+    boolean isRock = status == 200;
+    logger.warn("================ " + isRock + " ====================");
+
     try {
-      if (environment.getName().contains("rock")) {
+      if (isRock) {
+        if (environment.getName().contains("rock")) {
+          logger.warn(
+              "Using old name based rock setting. Please fix configuration for '"
+                  + environment.getName()
+                  + "'");
+        }
         return new RockConnectionFactory(environment).tryCreateConnection();
       } else {
         return new RserveConnectionFactory(environment).tryCreateConnection();

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,3 +9,22 @@ This template should help get you started developing with Vue 3 in Vite. The tem
 ## Can't log in in Armadillo UI
 
 Remove the session data / cookies from the swagger or the armadillo server on port 80, then try again
+
+## Updating tests
+
+- `yarn test --watch`
+
+## Views
+
+We have several views which use generic [Table](./src/components/Table.vue) component
+
+- [Profiles](./src/views/Profiles.vue)
+- [Projects](./src/views/Projects.vue)
+- [Users](./src/views/Users.vue)
+
+### Change a single profile, project or user
+
+Check for
+
+- `defineComponent()` in the `.vue`
+- visit the REST endpoint for seeing the data ie http://localhost:8080/ds-profiles`

--- a/ui/src/components/Table.vue
+++ b/ui/src/components/Table.vue
@@ -10,10 +10,7 @@
     </thead>
     <tbody>
       <slot name="extraRow"></slot>
-      <template
-        v-for="(dataRow, dataRowIndex) in dataToShow"
-        :key="dataRowIndex"
-      >
+      <template v-for="(dataRow, _) in dataToShow" :key="dataRowIndex">
         <tr
           v-if="getIndex(dataRow) != indexToEdit"
           class="align-middle"

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -44,6 +44,7 @@ export type Principal = {
 export type Profile = {
   name: string;
   image: string;
+  isRock: boolean;
   host: string;
   port: number;
   packageWhitelist: StringArray;

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -231,6 +231,7 @@ export default defineComponent({
       let columns: TypeObject = {
         name: "string",
         image: "string",
+        isRock: "boolean",
         host: "string",
         port: "string",
         packageWhitelist: "array",
@@ -347,6 +348,7 @@ export default defineComponent({
         name: "",
         image: "datashield/armadillo-rserver",
         host: "localhost",
+        isRock: true,
         port: this.firstFreePort,
         packageWhitelist: ["dsBase"],
         functionBlacklist: [],


### PR DESCRIPTION
- [ ] Java needs test for existing profiles
- [x] Vue does not? render boolean
- [ ] Needs PR #512 to add tests
- [ ] Making it show as checkbox (instead of `true|false` text) does not show [x]
- [ ] Is `isRock` enough to remove 'Not a Rock server' code (flow)?