### PR TITLE
Make rock selection better based on name or image

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -108,7 +108,9 @@ public class DockerService {
     }
 
     // TODO: have full port mapping in config or a by R server type?
-    int imageExposed = profileConfig.getName().contains("rock") ? 8085 : 6311;
+    boolean isRock =
+        profileConfig.getName().contains("rock") || profileConfig.getImage().contains("rock");
+    int imageExposed = isRock ? 8085 : 6311;
     ExposedPort exposed = ExposedPort.tcp(imageExposed);
     Ports portBindings = new Ports();
     portBindings.bind(exposed, Ports.Binding.bindPort(profileConfig.getPort()));

--- a/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
+++ b/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
@@ -19,6 +19,7 @@ public class RServerConnectionFactory implements RConnectionFactory {
 
   int doHead(String uri) {
     URL url;
+    int responseCode = -3;
     try {
       url = new URL(uri);
       HttpURLConnection connection;
@@ -26,20 +27,21 @@ public class RServerConnectionFactory implements RConnectionFactory {
         connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("HEAD");
         connection.getContentLength();
-        // -1 for rserve
-        // 200 for rock
+        // -1 for rserve : `curl --http0.9 --head http://localhost:6311`
+        // 200 for rock: `curl --head http://localhost:6311`
         return connection.getResponseCode();
       } catch (ConnectException e) {
-        // down
+        // server down
         return -99;
       } catch (SocketException e) {
         // Server not ready
+        logger.info("Server not ready on " + url, e);
         return -2;
       } catch (IOException e) {
-        e.printStackTrace();
+        logger.warn("Unexpected response on " + url, e);
       }
     } catch (MalformedURLException e) {
-      e.printStackTrace();
+      logger.warn("Unexpected url", e);
     }
     return -3;
   }

--- a/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
+++ b/r/src/main/java/org/molgenis/r/RServerConnectionFactory.java
@@ -1,5 +1,7 @@
 package org.molgenis.r;
 
+import java.io.IOException;
+import java.net.*;
 import org.molgenis.r.config.EnvironmentConfigProps;
 import org.molgenis.r.rock.RockConnectionFactory;
 import org.molgenis.r.rserve.RserveConnectionFactory;
@@ -15,10 +17,55 @@ public class RServerConnectionFactory implements RConnectionFactory {
     this.environment = environment;
   }
 
+  int doHead(String uri) {
+    URL url;
+    try {
+      url = new URL(uri);
+      HttpURLConnection connection;
+      try {
+        connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("HEAD");
+        connection.getContentLength();
+        // -1 for rserve
+        // 200 for rock
+        return connection.getResponseCode();
+      } catch (ConnectException e) {
+        // down
+        return -99;
+      } catch (SocketException e) {
+        // Server not ready
+        return -2;
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
+    }
+    return -3;
+  }
+
   @Override
   public RServerConnection tryCreateConnection() {
+    logger.warn("================ IsRock testing ====================");
+    String url = "http://" + environment.getHost() + ":" + environment.getPort();
+    int status = doHead(url);
+    if (status == -99) {
+      // server down
+      logger.warn("Container is down");
+    } else if (status == -2) {
+      logger.warn("Container service not ready");
+    }
+    boolean isRock = status == 200;
+    logger.warn("================ " + isRock + " ====================");
+
     try {
-      if (environment.getName().contains("rock")) {
+      if (isRock) {
+        if (environment.getName().contains("rock")) {
+          logger.warn(
+              "Using old name based rock setting. Please fix configuration for '"
+                  + environment.getName()
+                  + "'");
+        }
         return new RockConnectionFactory(environment).tryCreateConnection();
       } else {
         return new RserveConnectionFactory(environment).tryCreateConnection();


### PR DESCRIPTION
Inspired by #514 this PR makes it a little better and exposes the correct port from the container.

This is probably a better solution then go through the UI/Server stack as #514 tried to do since we plan to drop support for `rserve` soon.

A running server is either `rserve` or `rock` where `rserve` does not serve HTTP as curl shows depending on arguments

```zsg
curl --http0.9 --head http://localhost:6311
# curl: (8) Weird server reply

curl --no-http0.9 --head http://localhost:6311
# curl: (1) Received HTTP/0.9 when not allowed
```

while `rock` responds nicely with JSON

```zsh
curl --head http://localhost:6314 
```

>HTTP/1.1 200 OK
Date: Fri, 13 Oct 2023 11:55:01 GMT
Content-Type: application/json
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Length: 68

```zsh
curl http://localhost:6314 
```
> { "id": "rserver", "type": "rock", "cluster": "default","tags": [] }

## Test

The `scripts/release/release-test.R` uses the name 'rock' and ran as a whole testing rock images. Changing to another profile name say **roll** does not work as image is connected to string 'rock'

https://github.com/molgenis/molgenis-service-armadillo/blob/b4a959329929e74b3d07180f67f606d951553d82/scripts/release/release-test.R#L54-L55

![image](https://github.com/molgenis/molgenis-service-armadillo/assets/371014/d0d3d0e7-fcf3-430a-ab74-6af4441450da)
