### PR TITLE
fix: no such image

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -80,7 +80,7 @@ public class DockerService {
 
     try {
       InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(profileName).exec();
-      var tags = getImageTags(containerInfo.getName());
+      var tags = getImageTags(containerInfo.getImageId());
       return ContainerInfo.create(tags, ProfileStatus.of(containerInfo.getState()));
     } catch (ProcessingException e) {
       if (e.getCause() instanceof SocketException) {


### PR DESCRIPTION
DockerServiceTest.testGetProfileStatus

- [ ] `name` is `profileName`
- [ ] has **unused** `imageID`
- [ ] Should use `containerID` instead of `name`
  - `when(dockerClient.inspectContainerCmd(name).exec()).thenReturn(inspectContainerResponse);`
- [ ] Should use `imageID` instead of `name`
  - `when(dockerClient.inspectImageCmd(name).exec().getRepoTags()).thenReturn(tags);`

Trying to fix this makes tests fail.

## How to test

- run `release-test.R` and check the Insight log for "No such image"
> 2024-03-06 14:29:10.032 [http-nio-8080-exec-3|21ACB009] WARN  o.m.armadillo.profile.DockerService - Couldn't inspect image
com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"No such image: xenon:latest"}

### Docker

```bash
curl -s --unix-socket /var/run/docker.sock http:/v1.24/images/xenon/json 
# {"message":"No such image: xenon:latest"}
```

while following gives a expected answer

```bash
curl -s --unix-socket /var/run/docker.sock "http:/v1.24/images/datashield/rock-dolomite-xenon:latest/json"
# {"Id":"sha256:87038582f0 ....
```