### PR TITLE
Make sure release publish to GitHub and Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,9 @@ jobs:
           path: build/artifacts/armadillo-compose.zip
 
       - run:
-        ./gradlew release
+        name: Release
+        command: |
+          ./gradlew release
 
 workflows:
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,9 +175,9 @@ jobs:
           path: build/artifacts/armadillo-compose.zip
 
       - run:
-        name: Release
-        command: |
-          ./gradlew release
+          name: Release
+          command: |
+            ./gradlew release
 
 workflows:
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,8 @@ jobs:
       - store_artifacts:
           path: build/artifacts/armadillo-compose.zip
 
+      - run:
+        ./gradlew release
 
 workflows:
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,11 +173,14 @@ jobs:
 
       - store_artifacts:
           path: build/artifacts/armadillo-compose.zip
+          destination: armadillo-compose.zip
 
       - run:
           name: Release
           command: |
-            ./gradlew release
+            ./gradlew myNyxDiagnostics
+            ./gradlew release \
+              -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password
 
 workflows:
   build-deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,17 @@ We release through [Conventional Commits](https://www.conventionalcommits.org/en
 
 Use `./gradlew nyxMake` to see what is build in [build/distributions](./build/distributions/).
 
+### Major, Minor, Fix updates
+
+Each commit with `!` is a major update. So use it wisely. You can also add `BREAKING CHANGE:` in the long commit message format.
+
+### Checking log messages
+
 List messages to see usage of conventional commits from the past.
 
 ```sh
-git log --pretty=format:"%s" | cut -c -20
+# How many colon usages
+git log --pretty=format:"%s" | cut -d: -f1 | sort | uniq -c | sort -n
 ```
 
 ## Continuous integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ List messages to see usage of conventional commits from the past.
 git log --pretty=format:"%s" | cut -d: -f1 | sort | uniq -c | sort -n
 ```
 
+### Building locally
+
+```sh
+./gradlew clean assemble
+```
+
 ## Continuous integration
 
 - we test on each PR and merges on master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,10 @@ We have several components
 
 We release through [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) which autoincrement using [Semantic versioning](https://semver.org/).
 
+We use mooltiverse [Nyx](https://mooltiverse.github.io/nyx/guide/user/introduction/how-nyx-works/) for changelog and publishing to github.
+
+Run `./gradlew tasks --group Release` to see all release tasks
+
 Use `./gradlew nyxMake` to see what is build in [build/distributions](./build/distributions/).
 
 ### Major, Minor, Fix updates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ Each commit with `!` is a major update. So use it wisely. You can also add `BREA
 
 ### Checking log messages
 
+As [changelog template](./changelog-notes.tpl) uses the commit message it is good to check their quality.
+
 List messages to see usage of conventional commits from the past.
 
 ```sh

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,16 @@
+/* file: build.gradle
+ *
+ * Gradle related files:
+ *
+ * - file://./gradle.properties (to start the gradle process itself)
+ * - file://./settings.gradle (loaded before build.gradle)
+ *
+ * Sub projects
+ *
+ * - file://./armadillo/build.gradle
+ * - file://./r/build.gradle
+ * - file://./ui/build.gradle
+ */
 plugins {
     id 'org.springframework.boot' version '3.1.5'
     id "io.spring.dependency-management" version "1.1.3"

--- a/build.gradle
+++ b/build.gradle
@@ -30,15 +30,16 @@ println "Project previous version (nyx): " + rootProject.nyxState.releaseScope.p
 allprojects {
     group = 'org.molgenis'
 
-    if(rootProject.nyxState.releaseScope.previousVersion == rootProject.version ||
-            //temporarily also compare to 'v' because we are remove this prefix
-            rootProject.nyxState.releaseScope.previousVersion == "v" + rootProject.version ) {
-        version = rootProject.nyxState.releaseScope.previousVersion + "-SNAPSHOT"
-    }
-    else {
-        version = rootProject.version.replace("SNAPSHOT.1","SNAPSHOT")
-    }
-    version = version.replace("v","")
+    // Go with version of NYX
+    // if(rootProject.nyxState.releaseScope.previousVersion == rootProject.version ||
+    //         //temporarily also compare to 'v' because we are remove this prefix
+    //         rootProject.nyxState.releaseScope.previousVersion == "v" + rootProject.version ) {
+    //     version = rootProject.nyxState.releaseScope.previousVersion + "-SNAPSHOT"
+    // }
+    // else {
+    //     version = rootProject.version.replace("SNAPSHOT.1","SNAPSHOT")
+    // }
+    // version = version.replace("v","")
 }
 
 if(getGitNameRef().contains("tags/") && !getGitNameRef().contains("~")) {
@@ -182,6 +183,7 @@ task myNyxDiagnostics() {
     dependsOn nyxInfer
     doLast {
         println "Nyx dump > =============="
+        println "Current   : " + rootProject.nyxState.releaseScope.previousVersion
         println "Bump level: " + project.nyxState.bump
         println "Scheme:     " + project.nyxState.scheme.toString()
         println "Timestamp:  " + Long.valueOf(project.nyxState.timestamp).toString()

--- a/build.gradle
+++ b/build.gradle
@@ -176,3 +176,17 @@ task installLocalGitHook(type: Copy) {
     fileMode 0775
 }
 build.dependsOn installLocalGitHook
+
+task myNyxDiagnostics() {
+    // https://mooltiverse.github.io/nyx/guide/user/introduction/usage/#accessing-the-nyx-state-extra-project-property-from-build-scripts
+    dependsOn nyxInfer
+    doLast {
+        println "Nyx dump > =============="
+        println "Bump level: " + project.nyxState.bump
+        println "Scheme:     " + project.nyxState.scheme.toString()
+        println "Timestamp:  " + Long.valueOf(project.nyxState.timestamp).toString()
+        println "Version:    " + project.nyxState.version
+        println "# of commits: " + project.nyxState.releaseScope.significantCommits.size()
+        println "Nyx dump < =============="
+    }
+}

--- a/changelog-notes.tpl
+++ b/changelog-notes.tpl
@@ -1,0 +1,25 @@
+# Changelog
+
+
+{{#releases}}
+## Release [{{name}}](https://github.com/molgenis/molgenis-emx2/releases/{{name}}) ({{date}})
+
+{{#sections}}
+### {{name}}
+
+{{#commits}}
+* {{message.shortMessage}} ([{{#short7}}{{sha}}{{/short7}}](https://github.com/molgenis/molgenis-emx2/commit/{{#short7}}{{sha}}{{/short7}}))
+
+
+{{/commits}}
+{{^commits}}
+No changes.
+{{/commits}}
+{{/sections}}
+{{^sections}}
+No changes.
+{{/sections}}
+{{/releases}}
+{{^releases}}
+No releases.
+{{/releases}}

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,8 +34,12 @@ nyx {
     }
     releaseAssets {
         jar {
-            path = "build/libs/molgenis-armadillo-{{#replace from=\"v\"}}{{version}}{{/replace}}.jar"
-            fileName = "molgenis-armadillo-{{#replace from=\"v\"}}{{version}}{{/replace}}.jar"
+            // scrub of the 'v' from Nyx version ?
+            // build/lib/molgenis-armadillo-4.0.0-fd06cdc7.jar < adding hash ourselves
+            //                              v4.0.0-SNAPSHOT.1-fd06cdc7 adding hash + NYX
+            //           molgenis-armadillo-v4.0.0-SNAPSHOT.1 <=== by NYX !!!
+            path = "build/libs/*.jar"
+            // fileName = "molgenis-armadillo-*.jar"
             type = "application/java-archive"
         }
     }


### PR DESCRIPTION
As reported in #574 the artefact where wrongful named (and still not published on GitHub)

- [x] check for NYX version number (which depends on correct BREAKING) ... is now documented
- [ ] check for release on GitHub with fixed issues from #574
- [x] publish on GitHub done by 33c29b79bf1632e91c74e279379452de4b7e72db