### PR TITLE
fix: #591 loadTable returns tibble for arrow 13+

### DIFF
--- a/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
@@ -79,7 +79,7 @@ public class RExecutorServiceImpl implements RExecutorService {
       if (variables.isEmpty()) {
         execute(
             format(
-                "is.null(base::assign('%s', value={arrow::read_parquet('%s')}))",
+                "is.null(base::assign('%s', value={data.frame(arrow::read_parquet('%s', as_data_frame = FALSE))}))",
                 symbol, rFileName),
             connection);
       } else {
@@ -89,7 +89,7 @@ public class RExecutorServiceImpl implements RExecutorService {
                 + ")";
         execute(
             format(
-                "is.null(base::assign('%s', value={arrow::read_parquet('%s', col_select = %s)}))",
+                "is.null(base::assign('%s', value={data.frame(arrow::read_parquet('%s', as_data_frame = FALSE, col_select = %s))}))",
                 symbol, rFileName, colSelect),
             connection);
       }

--- a/r/src/test/java/org/molgenis/r/service/RExecutorServiceImplTest.java
+++ b/r/src/test/java/org/molgenis/r/service/RExecutorServiceImplTest.java
@@ -107,7 +107,7 @@ class RExecutorServiceImplTest {
     Resource resource = new InMemoryResource("Hello");
 
     when(rConnection.eval(
-            "is.null(base::assign('D', value={arrow::read_parquet('project_folder_table.parquet', col_select = tidyselect::any_of(c(\"col1\",\"col2\")))}))",
+            "is.null(base::assign('D', value={data.frame(arrow::read_parquet('project_folder_table.parquet', as_data_frame = FALSE, col_select = tidyselect::any_of(c(\"col1\",\"col2\"))))}))",
             false))
         .thenReturn(new RockResult(new REXPLogical(true)));
     when(rConnection.eval("base::unlink('project_folder_table.parquet')", false))
@@ -118,7 +118,7 @@ class RExecutorServiceImplTest {
 
     verify(rConnection)
         .eval(
-            "is.null(base::assign('D', value={arrow::read_parquet('project_folder_table.parquet', col_select = tidyselect::any_of(c(\"col1\",\"col2\")))}))",
+            "is.null(base::assign('D', value={data.frame(arrow::read_parquet('project_folder_table.parquet', as_data_frame = FALSE, col_select = tidyselect::any_of(c(\"col1\",\"col2\"))))}))",
             false);
     verify(rConnection).eval("base::unlink('project_folder_table.parquet')", false);
   }
@@ -128,7 +128,7 @@ class RExecutorServiceImplTest {
     Resource resource = new InMemoryResource("Hello");
 
     when(rConnection.eval(
-            "is.null(base::assign('D', value={arrow::read_parquet('project_folder_table.parquet')}))",
+            "is.null(base::assign('D', value={data.frame(arrow::read_parquet('project_folder_table.parquet', as_data_frame = FALSE))}))",
             false))
         .thenReturn(new RockResult(new REXPLogical(true)));
     when(rConnection.eval("base::unlink('project_folder_table.parquet')", false))
@@ -139,7 +139,7 @@ class RExecutorServiceImplTest {
 
     verify(rConnection)
         .eval(
-            "is.null(base::assign('D', value={arrow::read_parquet('project_folder_table.parquet')}))",
+            "is.null(base::assign('D', value={data.frame(arrow::read_parquet('project_folder_table.parquet', as_data_frame = FALSE))}))",
             false);
     verify(rConnection).eval("base::unlink('project_folder_table.parquet')", false);
   }

--- a/scripts/release/release-test.R
+++ b/scripts/release/release-test.R
@@ -771,6 +771,17 @@ conns <- datashield.login(logins = logindata, symbol = "core_nonrep", variables 
 
 cli_alert_info("Assigning table core_nonrep")
 datashield.assign.table(conns, "core_nonrep", sprintf("%s/2_1-core-1_0/nonrep", project1))
+datatype <- ds.class(x = "core_nonrep", datasources = conns)
+expected_type <- list()
+expected_type$armadillo = "data.frame"
+
+if (identical(datatype, expected_type)){
+    cli_alert_success("Assigned table is dataframe")
+} else {
+    cli_alert_danger("Assigned table not of expected type:")
+    print(datatype)
+}
+
 cli_alert_info("Assigning expression for core_nonrep$coh_country")
 datashield.assign.expr(conns, "x", expr=quote(core_nonrep$coh_country))
 


### PR DESCRIPTION
instead of dataframe

closes #591

How to test: 
Execute code in https://github.com/molgenis/molgenis-service-armadillo/issues/591 and see that the type now equals dataframe instead of tibble.