### PR TITLE
Update docs for #594

### DIFF
--- a/docs/ops/install/install_apache.md
+++ b/docs/ops/install/install_apache.md
@@ -1,0 +1,9 @@
+### Apache
+It is possible to run Molgenis Armadillo using Apache. We do however not provide any support regarding this configuration. Apache requires some additional configuration to get the `/storage/projects/{project}/objects/{object}` to work. When this endpoint doesn't work, tables cannot be assigned, subsets cannot be created and resources cannot be used. This basically means Armadillo is not usable. 
+
+Issues might be resolved with the following settings in the `ssl.conf`:
+```
+ProxyPass / http://localhost:8080/ nocanon
+AllowEncodedSlashes On
+```
+After setting this, don't forget to restart Apache. 

--- a/docs/ops/install/install_docker.md
+++ b/docs/ops/install/install_docker.md
@@ -1,0 +1,10 @@
+## Run Armadillo via docker compose
+For testing without having to installing Java you can run using docker:
+
+1. Install [docker-compose](https://docs.docker.com/compose/install/)
+2. Download this [docker-compose.yml](docker-compose.yml).
+3. Execute ```docker-compose up```
+4. Once it says 'Started' go to http://localhost:8080 to see your Armadillo running.
+
+The command must run in same directory as downloaded docker file. We made docker available via 'docker.sock' so we can start/stop DataSHIELD profiles. Alternatively you must include the datashield profiles into this docker-compose. You can override all application.yaml settings via environment variables 
+(see commented code in docker-compose file).

--- a/docs/ops/install/install_java.md
+++ b/docs/ops/install/install_java.md
@@ -1,0 +1,13 @@
+## Run Armadillo using java commandline
+Software developers often run Armadillo as java jar file: 
+
+1. Install Java and Docker (for the DataSHIELD profiles)
+2. Download Armadillo jar file from [releases](https://github.com/molgenis/molgenis-service-armadillo/releases), for example:
+[molgenis-armadillo-3.3.0.jar](https://github.com/molgenis/molgenis-service-armadillo/releases/download/V3.3.0/)
+3. Run armadillo using ```java -jar molgenis-armadillo-3.3.0.jar```
+4. Go to http://localhost:8080 to see your Armadillo running.
+
+Default Armadillo will start with only 'basic-auth' and user 'admin' with password 'admin'. You can enable 'oidc' for connecting more users. You can change 
+by providing and editing [application.yaml](application.template.yml) file
+in your working directory and then run command above again.
+

--- a/docs/ops/installing.md
+++ b/docs/ops/installing.md
@@ -1,47 +1,49 @@
 # Armadillo installation
-Armadillo requires Java to run, Docker to access the DataSHIELD profiles, and OIDC for authentication (not needed for local tests). Below instructions how to run Armadillo directly from Java, as a Docker container, as a service on Ubuntu or from source code.
+
+Armadillo requires:
+
+- Java to run the application
+- Docker to access the DataSHIELD profiles
+- and OIDC for authentication (not needed for local tests).
+
+Below instructions how to run Armadillo directly from Java, as a Docker container, as a service on Ubuntu or from source code.
+
 Note that for production you should add a https proxy for essential security. And you might need to enable 'Docker socket' on your docker service.
 
-## Run Armadillo using java commandline
-Software developers often run Armadillo as java jar file: 
+We support Ubuntu installations in this document.
 
-1. Install Java and Docker (for the DataSHIELD profiles)
-2. Download Armadillo jar file from [releases](https://github.com/molgenis/molgenis-service-armadillo/releases), for example:
-[molgenis-armadillo-3.3.0.jar](https://github.com/molgenis/molgenis-service-armadillo/releases/download/V3.3.0/)
-3. Run armadillo using ```java -jar molgenis-armadillo-3.3.0.jar```
-4. Go to http://localhost:8080 to see your Armadillo running.
+## Install Armadillo as service on Ubuntu
 
-Default Armadillo will start with only 'basic-auth' and user 'admin' with password 'admin'. You can enable 'oidc' for connecting more users. You can change 
-by providing and editing [application.yaml](application.template.yml) file
-in your working directory and then run command above again.
-
-## Run Armadillo via docker compose
-For testing without having to installing Java you can run using docker:
-
-1. Install [docker-compose](https://docs.docker.com/compose/install/)
-2. Download this [docker-compose.yml](docker-compose.yml).
-3. Execute ```docker-compose up```
-4. Once it says 'Started' go to http://localhost:8080 to see your Armadillo running.
-
-The command must run in same directory as downloaded docker file. We made docker available via 'docker.sock' so we can start/stop DataSHIELD profiles. Alternatively you must include the datashield profiles into this docker-compose. You can override all application.yaml settings via environment variables 
-(see commented code in docker-compose file).
-
-## Run Armadillo as service on Ubuntu
-We run Armadillo in production as a Linux service on Ubuntu, ensuring it gets restarted when the server is rebooted. You might be able to reproduce also on
-CentOS (using yum instead of apt).
+We run Armadillo in production as a Linux service on Ubuntu, ensuring it gets restarted when the server is rebooted. You might be able to reproduce also on CentOS (using yum instead of apt).
 
 ### 1. Install necessary software
-```
+
+```bash
 apt update
 apt install openjdk-19-jre-headless
 apt install docker.io 
 ```
+
 Note: you might need 'sudo'
 
 ### 2. Run installation script
+
 This step will install most recent [release](https://github.com/molgenis/molgenis-service-armadillo/releases):
+
+#### Download the setup script
+
 ```
 wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh 
+```
+
+#### Run the install script
+
+Adapt the following install command to suit your situation. Use `--help` to see the options.
+
+> Note: https://lifecycle-auth.molgenis.org is MOLGENIS provided OIDC service but
+you can  also use your own, see FAQ below.
+
+```bash
 bash armadillo-setup.sh \
     --admin-user admin \
     --admin-password xxxxx 
@@ -52,13 +54,13 @@ bash armadillo-setup.sh \
     --oidc_clientsecret secret \
     --cleanup 
 ```
-Note: adapt install command to suit your situation. Use --help to see the options. https://lifecycle-auth.molgenis.org is MOLGENIS provided OIDC service but
-you can  also use your own, see FAQ below.
 
 ## Setting up Proxy Server
+
 We highly recommend using `nginx` with MolgenisArmadillo. We have configured it the following way in
 ` /etc/nginx/sites-available/armadillo.conf`:
-```
+
+```nginx
 server {
   listen 80;
   server_name urlofyourserver.org
@@ -73,12 +75,9 @@ server {
   }
 }
 ```
-### Apache
-It is possible to run Molgenis Armadillo using Apache. We do however not provide any support regarding this configuration. Apache requires some additional configuration to get the `/storage/projects/{project}/objects/{object}` to work. When this endpoint doesn't work, tables cannot be assigned, subsets cannot be created and resources cannot be used. This basically means Armadillo is not usable. 
 
-Issues might be resolved with the following settings in the `ssl.conf`:
-```
-ProxyPass / http://localhost:8080/ nocanon
-AllowEncodedSlashes On
-```
-After setting this, don't forget to restart Apache. 
+## Install alternatives
+
+- On local machine using [java](./install/install_java.md)
+- Armidillo running as a [Docker](./install/install_docker.md) container.
+- [Apache](./install/install_apache.md)

--- a/docs/ops/installing.md
+++ b/docs/ops/installing.md
@@ -1,18 +1,42 @@
 # Armadillo installation
 
+BEGIN: remove
+
+Documentation bugs:
+- ?how to enable docker socket?
+- ?apt install nginx versus redhat flavour?
+- ?how to enroll OIDC process
+- !elaborate in install script!
+  - it requires OIDC config otherwise Armadillo crashes
+    - removing the section from `/etc/armadillo/application.yml` fixed it
+- script installed `datashield/armadillo-rserver` initially
+- `./release-test.R` requires xenon profile
+  - adding profile `datashield/rock-dolomite-xenon:latest` ends with
+    - >   Error: Could not start [xenon]: SyntaxError: The string did not match the expected pattern..
+  - expected auto install of rock
+- adding profile does not randomize ... it that bad?
+END: remove
+
+> This guide assumes using Ubuntu Server LTS. See [Install alternatives](#install-alternatives) below.
+
 Armadillo requires:
 
 - Java to run the application
 - Docker to access the DataSHIELD profiles
 - and OIDC for authentication (not needed for local tests).
+- you might need to enable 'Docker socket' on your docker service.
 
-Below instructions how to run Armadillo directly from Java, as a Docker container, as a service on Ubuntu or from source code.
+## Preparation
 
-Note that for production you should add a https proxy for essential security. And you might need to enable 'Docker socket' on your docker service.
+If you want to use an OIDC authentication service you need the credentials first for setting up Armadillo.
 
-We support Ubuntu installations in this document.
+### OIDC
 
-## Install Armadillo as service on Ubuntu
+- OIDC service url https://lifecycle-auth.molgenis.org
+- OIDC Client ID
+- OIDC Client Secret
+
+## Installing Armadillo as service
 
 We run Armadillo in production as a Linux service on Ubuntu, ensuring it gets restarted when the server is rebooted. You might be able to reproduce also on CentOS (using yum instead of apt).
 
@@ -28,7 +52,9 @@ Note: you might need 'sudo'
 
 ### 2. Run installation script
 
-This step will install most recent [release](https://github.com/molgenis/molgenis-service-armadillo/releases):
+This step will install most recent [release](https://github.com/molgenis/molgenis-service-armadillo/releases)
+
+After installation the Armadillo application is installed with the given configuration and its service.
 
 #### Download the setup script
 
@@ -36,9 +62,15 @@ This step will install most recent [release](https://github.com/molgenis/molgeni
 wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh 
 ```
 
+Make sure `armadillo-setup.sh` is executable using
+
+```bash
+chmod u+x armadillo-setup.sh
+```
+
 #### Run the install script
 
-Adapt the following install command to suit your situation. Use `--help` to see the options.
+Adapt the following install command to suit your situation. Use `--help` to see all options.
 
 > Note: https://lifecycle-auth.molgenis.org is MOLGENIS provided OIDC service but
 you can  also use your own, see FAQ below.
@@ -52,7 +84,24 @@ bash armadillo-setup.sh \
     --oidc_url https://lifecycle-auth.molgenis.org \
     --oidc_clientid clientid \
     --oidc_clientsecret secret \
-    --cleanup 
+```
+
+#### File locations
+
+This creates the follow files/directories
+
+```bash
+/etc/armadillo/application.yml
+/etc/systemd/system/armadillo.service
+/usr/share/armadillo/*
+/var/log/armadillo/*
+```
+
+## Start and stop armadillo
+
+```bash
+systemctl stop armadillo
+systemctl start armadillo
 ```
 
 ## Setting up Proxy Server
@@ -64,7 +113,7 @@ We highly recommend using `nginx` with MolgenisArmadillo. We have configured it 
 server {
   listen 80;
   server_name urlofyourserver.org
-  include /etc/nginx/global.d/*.conf;
+  include /etc/nginx/conf.d/*.conf;
   location / {
   proxy_pass http://localhost:8080;
   client_max_body_size 0;

--- a/docs/ops/installing.md
+++ b/docs/ops/installing.md
@@ -1,40 +1,51 @@
 # Armadillo installation
 
-BEGIN: remove
+> This guide assumes using Ubuntu Server LTS as the installation script expect the `systemd` service. See [Install alternatives](#install-alternatives) below.
 
-Documentation bugs:
-- ?how to enable docker socket?
-- ?apt install nginx versus redhat flavour?
-- ?how to enroll OIDC process
-- !elaborate in install script!
-  - it requires OIDC config otherwise Armadillo crashes
-    - removing the section from `/etc/armadillo/application.yml` fixed it
-- script installed `datashield/armadillo-rserver` initially
-- `./release-test.R` requires xenon profile
-  - adding profile `datashield/rock-dolomite-xenon:latest` ends with
-    - >   Error: Could not start [xenon]: SyntaxError: The string did not match the expected pattern..
-  - expected auto install of rock
-- adding profile does not randomize ... it that bad?
-END: remove
+## Requirements
 
-> This guide assumes using Ubuntu Server LTS. See [Install alternatives](#install-alternatives) below.
+## Server resources
 
-Armadillo requires:
+You need a server or virtual machine to deploy the Armadillo stack. The specifications of the resource are the following, depending on the participant size of the cohort you are running.
 
-- Java to run the application
-- Docker to access the DataSHIELD profiles
-- and OIDC for authentication (not needed for local tests).
-- you might need to enable 'Docker socket' on your docker service.
+| Participants  | Memory (in GB) | Diskspace (in GB) | CPU cores |
+| ------------- | -------------- | ----------------- | --------- |
+| 0-20.000      | 8              | 100               | 4         |
+| 20.000-70.000 | 16             | 100               | 4         |
+| 70.000 >      | 32             | 150               | 8         |
 
-## Preparation
+In case of using dsOmics this setup can be rather bigger. Please contact molgenis-operations@umcg.nl for the latest specifications.
 
-If you want to use an OIDC authentication service you need the credentials first for setting up Armadillo.
+## Software requirements
 
-### OIDC
+* Java 17 JRE or JDK
+* Docker
 
-- OIDC service url https://lifecycle-auth.molgenis.org
+In addition to these, there are other optional components you may wish to install, such as setting up nginx as a reverse proxy. 
+
+## Domain
+
+An domain or an hostname ie `cohort.armadillo.domain.org` is required to run Armadillo.
+
+This domain is needed for the installation script.
+
+## Authentication
+
+Before we start with the deployment of Armadillo you will need to register your domain that you are going to use with your Armadillo on the DataSHIELD authentication server. This allows you to delegate the authentication and user management. The authorization will still be under the control of the Data Manager (who gets access and who don't get access) within your armadillo installation.
+
+To registrate you will need to send a mail to `molgenis-support@umcg.nl` with the [chosen domains](#domain) and the e-mail adres of the Data Manager who is granted admin permissions in Armadillo. Also add to the mail that you want to register for the the DataSHIELD authentication server and if you belong to a project like Lifecycle, Athlete or Longitools.
+
+When the Armadillo domain is registrerd you will get an mail back with data that need to be inserted in step 2.
+
+The values needed are:
+
+- OIDC service url i.e. https://lifecycle-auth.molgenis.org
 - OIDC Client ID
 - OIDC Client Secret
+
+## Securing the connection
+
+You need a SSL certificate to configuring the front-end proxy and make the browser use **https** before putting data on the server.
 
 ## Installing Armadillo as service
 
@@ -56,11 +67,13 @@ This step will install most recent [release](https://github.com/molgenis/molgeni
 
 After installation the Armadillo application is installed with the given configuration and its service.
 
-#### Download the setup script
+#### 2.1 Download the setup script
 
 ```
 wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh 
 ```
+
+Or manually download the setup script via right click on this [link](https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh) (Right mouse 'save as')
 
 Make sure `armadillo-setup.sh` is executable using
 
@@ -68,7 +81,21 @@ Make sure `armadillo-setup.sh` is executable using
 chmod u+x armadillo-setup.sh
 ```
 
-#### Run the install script
+The installation script requires some arguments:
+
+| Argument         | Application   |
+| ---------------- | ------------- |
+| admin-user       | Local armadillo admin user            |
+| admin-password   | Secure password for the admin user    |
+| datadir          | The location where the data is stored. This directory should be have enough diskspace en could be backuped (Default &rarr; /usr/share/armadillo/data)|
+| domain           | The URL where armadillo is listening on. For example: cohort.armadillo.domain.org  |
+|||
+|oidc              | Enable OIDC, see [authentication](#Authentication) |
+|oidc_url          | Given oidc URL |
+|oidc_clientid     | Given client ID|
+|oidc_clientsecret | Given secret ID|
+
+### 2.2 Run the install script
 
 Adapt the following install command to suit your situation. Use `--help` to see all options.
 
@@ -79,16 +106,16 @@ you can  also use your own, see FAQ below.
 bash armadillo-setup.sh \
     --admin-user admin \
     --admin-password xxxxx 
-    --domain my.server.com \
+    --domain armadillo.cohort.study.com \
     --oidc \
     --oidc_url https://lifecycle-auth.molgenis.org \
     --oidc_clientid clientid \
     --oidc_clientsecret secret \
 ```
 
-#### File locations
+## File locations
 
-This creates the follow files/directories
+The script creates using default values the follow files and directories:
 
 ```bash
 /etc/armadillo/application.yml
@@ -97,22 +124,28 @@ This creates the follow files/directories
 /var/log/armadillo/*
 ```
 
-## Start and stop armadillo
+## Controlling the Armadillo service
 
 ```bash
+systemctl status armadillo
+
 systemctl stop armadillo
+
 systemctl start armadillo
 ```
 
+After the installation is complet armadillo is listening on port 8080. Test the setup by visiting `http://armadillo.cohort.study.com:8080` or type in the terminal `wget http://localhost:8080` to see a text response.
+
+> Note: the Armadillo website is not secure yet so you need to setup a *front-end* proxy.
+
 ## Setting up Proxy Server
 
-We highly recommend using `nginx` with MolgenisArmadillo. We have configured it the following way in
-` /etc/nginx/sites-available/armadillo.conf`:
+We highly recommend using `nginx` with MolgenisArmadillo. We use the follow configuration located in `/etc/nginx/sites-available/armadillo.conf`
 
 ```nginx
 server {
   listen 80;
-  server_name urlofyourserver.org
+  server_name armadillo.cohort.study.com
   include /etc/nginx/conf.d/*.conf;
   location / {
   proxy_pass http://localhost:8080;
@@ -125,8 +158,23 @@ server {
 }
 ```
 
+> Note: the above is still not secure but not you can reach Armadillo from `http://armadillo.cohort.study.com`.
+
+To secure the communication using https we have a [nginx example](https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/conf/armadillo-nginx.conf)
+
+## Backups
+
+A good start for backuping data is the /usr/share/armadillo and /etc/armadillo. If you gave another datadir as setup option you also should backup this directory. For disaster backups you should contact your IT department.
+
 ## Install alternatives
 
 - On local machine using [java](./install/install_java.md)
 - Armidillo running as a [Docker](./install/install_docker.md) container.
 - [Apache](./install/install_apache.md)
+
+For questions on other linux release you can email molgenis-operations@umcg.nl
+
+## What's next?
+
+* [For the server owner or data manager who need to put data on to the server](https://molgenis.github.io/molgenis-r-armadillo/)
+* [For the researcher who want to start analyzing the data on the server](https://molgenis.github.io/molgenis-r-datashield/)

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -4,7 +4,7 @@ This is the developer guide for the installation scripts
 
 > NOTE: When moving this directory it has consequences for the documentation.
 
-- [./armadillo-setup.sh](armadillo-setup.sh) is referenced in the online documentation.
+- [./armadillo-setup.sh](./armadillo-setup.sh) is referenced in the online documentation.
 - [./armadillo-check-update.sh](./armadillo-check-update.sh) is WIP [Issue 606](https://github.com/molgenis/molgenis-service-armadillo/issues/606)
 - [./conf/application.yml](./conf/application.yml) is used for the installations script but is a WIP as we do have [../../application.template.yml](../../application.template.yml) which should be used instead.
 - [./conf/armadillo-nginx.conf](./conf/armadillo-nginx.conf) is an example file

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -1,76 +1,10 @@
 # Armadillo as a service installation
 
-This guide leads you step by step through the process of installing armadillo 3 as a service and configuring the components.
+This is the developer guide for the installation scripts
 
-## Requirements
-This script requires an systemd service based linux operating system. Armadillo 3 is tested on the latest LTS release of Ubuntu. For questions on other linux release you can email molgenis-operations@umcg.nl
-> ## Server resources
->
-> You need a server or virtual machine to deploy the Armadillo stack. The specifications of the resource are the following, depending on the participant size of the cohort you are running.
->
-> | Participants  | Memory (in GB) | Diskspace (in GB) | CPU cores |
-> | ------------- | -------------- | ----------------- | --------- |
-> | 0-20.000      | 8              | 100               | 4         |
-> | 20.000-70.000 | 16             | 100               | 4         |
-> | 70.000 >      | 32             | 150               | 8         |
+> NOTE: When moving this directory it has consequences for the documentation.
 
-In case of using dsOmics this setup can be rather bigger. Please contact molgenis-operations@umcg.nl for the latest specifications.
-
-## Software requirements
-
-* Java 17 JRE or JDK
-* Docker
-
-In addition to these, there are other optional components you may wish to install, such as setting up nginx as a reverse proxy. 
-
-## Domain
-An domain or an hostname is required to run armadillo 3. This domain should be used for installation, for example: cohort.armadillo.domain.org
-
-### Authentication
-Before we start with the deployment of Armadillo you will need to register your domain that you are going to use with your Armadillo on the DataSHIELD authentication server. This allows you to delegate the authentication and user management. The authorization will still be under the control of the Data Manager(who gets access and who don't get access) within your armadillo installation. To registrate you will need to send a mail to `molgenis-support@umcg.nl` with the [chosen domains](#domain) and the e-mail adres of the Data Manager who is granted admin permissions in Armadillo. Also add to the mail that you want to register for the the DataSHIELD authentication server and if you belong to a project like Lifecycle, Athlete or Longitools. When the Armadillo is registrerd you will get an mail back with data that need to be inserted in step 2.
-
-
-##### Step 1
-Download setup script via right click on this [link](https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh) (Right mouse 'save as') or via commandline:
-```bash
-wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh
-```
-##### Step 2
-The installation script requires some arguments:
-| Argument                                    | Application   |
-| ------------------------------------------- | ------------- |
-| admin-user                                  | Local armadillo admin user            |
-| admin-password                              | Secure password for the admin user    |
-| datadir                                     | The location where the data is stored. This directory should be have enough diskspace en could be backuped (Default &rarr; /usr/share/armadillo/data)|
-| domain                                      | The URL where armadillo is listening on. For example: cohort.armadillo.domain.org  |
-|||
-|oidc                                       | Enable OIDC, see [authentication](#Authentication) |
-|oidc_url                                   | Given oidc URL |
-|oidc_clientid | Given client ID|
-|oidc_clientsecret | Given secret ID|
-
-```bash
-bash armadillo-setup.sh --admin-user admin --admin-password xxxxxxxx --domain armadillo.cohort.study.com --oidc --oidc_url https://lifecycle-auth.molgenis.org --oidc_clientid xxxxx --oidc_clientsecret xxxx'
-```
-
-#### Step 3
-After installation armadillo is listening on port 8080. 
-Test the setup on http://domain:8080 or on the localhost http://localhost:8080
-
-# ProxyPass  SSL / certificates
-Armadillo 3 is a standalone application wich is listening on port 8080. 
-You can set up a front-end proxy if you'd like to proxypass to this port. This can be a simple HTTP server, something like Apache HTTPD or nginx, These can be useful for managing multiple URLs or sites through a single server machine, configuring HTTPS with SSL certificates without involving Armadillo. This is completely optional.
-
-We have an example for nginx: [Example](https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/conf/armadillo-nginx.conf)
-
-
-### Updates
-The above setup script is creating an update check. Every week (cron) armadillo checks and installing the latest updates of armadillo.
-
-### Backups
-A good start for backuping data is the /usr/share/armadillo and /etc/armadillo. If you gave another datadir as setup option you also should backup this directory. For disaster backups you should contact your IT department.
-
-## What's next?
-
-* [For the server owner or data manager who need to put data on to the server](https://molgenis.github.io/molgenis-r-armadillo/)
-* [For the researcher who want to start analyzing the data on the server](https://molgenis.github.io/molgenis-r-datashield/)
+- [armadillo-setup.sh](armadillo-setup.sh) is referenced in the online documentation.
+- [./armadillo-check-update.sh](./armadillo-check-update.sh) is WIP [Issue 606](https://github.com/molgenis/molgenis-service-armadillo/issues/606)
+- [./conf/application.yml](./conf/application.yml) is used for the installations script but is a WIP as we do have [../../application.template.yml](../../application.template.yml) which should be used instead.
+- [./conf/armadillo-nginx.conf](./conf/armadillo-nginx.conf) is an example file

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -4,7 +4,7 @@ This is the developer guide for the installation scripts
 
 > NOTE: When moving this directory it has consequences for the documentation.
 
-- [armadillo-setup.sh](armadillo-setup.sh) is referenced in the online documentation.
+- [./armadillo-setup.sh](armadillo-setup.sh) is referenced in the online documentation.
 - [./armadillo-check-update.sh](./armadillo-check-update.sh) is WIP [Issue 606](https://github.com/molgenis/molgenis-service-armadillo/issues/606)
 - [./conf/application.yml](./conf/application.yml) is used for the installations script but is a WIP as we do have [../../application.template.yml](../../application.template.yml) which should be used instead.
 - [./conf/armadillo-nginx.conf](./conf/armadillo-nginx.conf) is an example file

--- a/scripts/install/armadillo-setup.sh
+++ b/scripts/install/armadillo-setup.sh
@@ -10,7 +10,6 @@ ARMADILLO_LOG_PATH=/var/log/armadillo
 ARMADILLO_AUDITLOG=$ARMADILLO_LOG_PATH/audit.log
 ARMADILLO_DATADIR=$ARMADILLO_PATH/data
 
-
 handle_args() {
     while :
     do
@@ -87,14 +86,11 @@ handle_args() {
         exit 1;
       fi
     fi
-
-
 }
 
-
 setup_environment() {
-    mkdir -p $ARMADILLO_PATH/application
-    mkdir -p $ARMADILLO_PATH/services
+    mkdir -p "$ARMADILLO_PATH/application"
+    mkdir -p "$ARMADILLO_PATH/services"
     mkdir -p "$ARMADILLO_LOG_PATH"
     mkdir -p "$ARMADILLO_CFG_PATH"
     mkdir -p "$ARMADILLO_DATADIR"
@@ -164,11 +160,8 @@ setup_armadillo_config() {
     sed -i -e 's/@ARMADILLODOMAIN@/'"$ARMADILLO_DOMAIN"'/' $ARMADILLO_CFG_PATH/application.yml
     sed -i -e 's|# oidc-admin-user: @ADMIN_EMAIL@|oidc-admin-user: '"$ARMADILLO_OIDC_ADMIN_EMAIL"'|' $ARMADILLO_CFG_PATH/application.yml
   fi
-  
-  
-  
-  echo "Config downloaded"
 
+  echo "Config downloaded"
 }
 
 download_armadillo() {
@@ -188,7 +181,6 @@ download_armadillo() {
 
   DL_URL=https://github.com/molgenis/molgenis-service-armadillo/releases/download/v$ARMADILLO_VERSION/molgenis-armadillo-$ARMADILLO_VERSION.jar
 
- 
   if validate_url $DL_URL; then
 
     wget -q -O $ARMADILLO_PATH/application/armadillo-"$ARMADILLO_VERSION".jar "$DL_URL"
@@ -303,13 +295,7 @@ parameters_help() {
     echo '      --oidc_clientid               Client id of the oidc config'
     echo '      --oidc_clientsecret           Secret of the client'
     echo '      --admin-email                 Email adres of the oidc Admin User'
-    
-
-    
 }
-
-
-
 
 if [ "$#" -eq 0 ]; then
     echo 'No parameters provided, please provide the correct parameters'

--- a/scripts/install/conf/application.yml
+++ b/scripts/install/conf/application.yml
@@ -7,7 +7,7 @@ armadillo:
 
   profiles:
     - name: default
-      image: datashield/armadillo-rserver
+      image: datashield/rock-base:latest
       port: 6311
       package-whitelist:
         - dsBase


### PR DESCRIPTION
Documentation bugs:

- [x] ?how to enable docker socket?
- [x]  ?apt install nginx versus redhat flavour?
- [x]  ?how to enroll OIDC process
- [x]  !elaborate in install script!
  - it requires OIDC config otherwise Armadillo crashes
    - removing the section from `/etc/armadillo/application.yml` fixed it
- [x]  script installed `datashield/armadillo-rserver` initially
- [x]  `./release-test.R` requires xenon profile
  - adding profile `datashield/rock-dolomite-xenon:latest` ends with
    - >   Error: Could not start [xenon]: SyntaxError: The string did not match the expected pattern..
  - expected auto install of rock
- [x]  adding profile does not randomize ... it that bad?
