### PR TITLE
Add a rock controller

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ nyx {
         items {
             mainline {
                 matchBranches = "master"
+                publish = "true"
                 publishPreRelease = "true"
                 description = "{{#fileContent}}CHANGELOG.md{{/fileContent}}"
                 publicationServices = ["github"]


### PR DESCRIPTION
This is a script/sub tree for some future rock related projects.

- rockctl is a rock controller to query its status and sessions