### PR TITLE
Feat/make update testable

### DIFF
--- a/scripts/install/armadillo-check-update.sh
+++ b/scripts/install/armadillo-check-update.sh
@@ -23,7 +23,7 @@ REQUESTED_VERSION=""
 if [ -n "$1" ]
 then
   REQUESTED_VERSION="$1"
-  echo "Will fetch requested version '$REQUESTED_VERSION' shortly"
+  echo "Fetch version  : $REQUESTED_VERSION"
 fi
 
 
@@ -49,11 +49,16 @@ if [ $MODE = "dev" ]; then
   mkdir -p "$ARMADILLO_PATH/application"
 fi
 
+echo "Mode           : $MODE"
+echo "Auto install   : $AUTO_INSTALL"
+echo "Armadillo home : $ARMADILLO_PATH"
+
 
 check_armadillo_update() {
   # Check the running Armadillo version whether it is upgradeable.
   VERSION_USED=$(curl --location --silent --header 'Accept: application/json' http://localhost:8080/actuator/info | sed -e 's/.*"version":"\([^"]*\)".*/\1/')
-  echo "Current running version $VERSION_USED"
+  echo "Current version: $VERSION_USED"
+  echo ""
   GREATEST=$(compare_versions "$VERSION_USED" "$ARMADILLO_VERSION_MINIMAL")
   if [ "$GREATEST" = "$ARMADILLO_VERSION_MINIMAL" ]; then
     echo "Current version is not upgradeable. It must be higher then $ARMADILLO_VERSION_MINIMAL"
@@ -84,24 +89,24 @@ check_armadillo_update() {
 
   if validate_url "$DL_URL"; then
   {
-    # Skip on dev
-    [ $MODE = "dev" ] || systemctl stop armadillo
-
     DOWNLOAD_DESTINATION_JAR="$ARMADILLO_PATH/application/armadillo-$NEXT_VERSION.jar"
     if [[ -f "$DOWNLOAD_DESTINATION_JAR" ]]; then
-      echo "File already downloaded"
+      echo "File already downloaded in $DOWNLOAD_DESTINATION_JAR"
     else
       echo "Downloading $DOWNLOAD_DESTINATION_JAR"
       wget -q -O "$DOWNLOAD_DESTINATION_JAR" "$DL_URL"
     fi
 
     if [ "$AUTO_INSTALL" = "y" ]; then
+      # Skip on dev
+      [ $MODE = "dev" ] || systemctl stop armadillo
+
       ln -s -f $DOWNLOAD_DESTINATION_JAR $ARMADILLO_PATH/application/armadillo.jar
       echo "armadillo $NEXT_VERSION updated"
-    fi
 
-    # Skip on dev
-    [ $MODE = "dev" ] || systemctl start armadillo
+      # Skip on dev
+      [ $MODE = "dev" ] || systemctl start armadillo
+    fi
   }
   else
     echo "Somehow $DL_URL is not a valid page."

--- a/scripts/install/armadillo-check-update.sh
+++ b/scripts/install/armadillo-check-update.sh
@@ -17,7 +17,6 @@ echo "Updater version: $ARMADILLO_UPDATER_VERSION"
 
 # Change mode to dev when testing locally
 MODE=prd
-MODE=dev
 
 REQUESTED_VERSION=""
 if [ -n "$1" ]
@@ -31,15 +30,10 @@ fi
 ARMADILLO_GITHUB=https://github.com/molgenis/molgenis-service-armadillo
 
 # Minimal version we support
-ARMADILLO_VERSION_MINIMAL=4.0.0
+ARMADILLO_VERSION_MINIMAL=3.9999.0
 
 # Change to y to auto upgrade
-AUTO_INSTALL=n
-
-# To prevent a downgrade do not auto install
-if [ -n "$REQUESTED_VERSION" ]; then
-  AUTO_INSTALL=n
-fi
+AUTO_INSTALL=y
 
 # System variables
 ARMADILLO_PATH=/usr/share/armadillo
@@ -93,7 +87,7 @@ check_armadillo_update() {
     if [[ -f "$DOWNLOAD_DESTINATION_JAR" ]]; then
       echo "File already downloaded in $DOWNLOAD_DESTINATION_JAR"
     else
-      echo "Downloading $DOWNLOAD_DESTINATION_JAR"
+      echo "Downloading $NEXT_VERSION to $DOWNLOAD_DESTINATION_JAR"
       wget -q -O "$DOWNLOAD_DESTINATION_JAR" "$DL_URL"
     fi
 

--- a/scripts/install/armadillo-check-update.sh
+++ b/scripts/install/armadillo-check-update.sh
@@ -1,49 +1,103 @@
 #!/bin/bash
 
-ARMADILLO_UPDATESCR_VERSION=0.0.1
-ARMADILLO_URL=https://github.com/molgenis/molgenis-service-armadillo/
+# Update or check only for updates
+# We assume all version are 3 numbers x.y.z
+#
+# Giving an argument that must be a version which forces this version to download.
+#
+# To test locally
+# - set MODE=dev
+# - To prevent update ARMADILLO_VERSION_MINIMAL to a future update
+
+ARMADILLO_UPDATER_VERSION=0.1.0
+
+echo "Updater version: $ARMADILLO_UPDATER_VERSION"
+
+# Change mode to dev when testing locally
+MODE=prd
+MODE=dev
+
+PINNED_VERSION=""
+if [ -n "$1" ]
+then
+  PINNED_VERSION="$1"
+  echo "Will fetch '$PINNED_VERSION' shortly"
+fi
+
+
+
+# Armadillo variables
+ARMADILLO_GITHUB=https://github.com/molgenis/molgenis-service-armadillo
+
+# Minimal version we support
+ARMADILLO_VERSION_MINIMAL=4.0.0
+
+# Change to y to auto upgrade
+AUTO_INSTALL=n
+
+
+# System variables
 ARMADILLO_PATH=/usr/share/armadillo
-
-
-
+if [ $MODE = "dev" ]; then
+  ARMADILLO_PATH=../../../build/armadillo-check-update
+  mkdir -p "$ARMADILLO_PATH/application"
+fi
 
 check_armadillo_update() {
-
-  VERSION_USED=$(curl -L -s -H 'Accept: application/json' -s http://localhost:8080/actuator/info | sed -e 's/.*"version":"\([^"]*\)".*/\1/')
-  LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' -s $ARMADILLO_URL/releases/latest)
-  ARMADILLO_LATEST_VERSION=$(echo "$LATEST_RELEASE" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/' | sed -e s/.*v//)
-
-  if [[ "$ARMADILLO_LATEST_VERSION" =~ 2.2.3 ]]; then
-  {
-    
-    echo "Update of Armadillo 2 version is not supported on this system"
+  # check the local running version
+  VERSION_USED=$(curl --location --silent --header 'Accept: application/json' http://localhost:8080/actuator/info | sed -e 's/.*"version":"\([^"]*\)".*/\1/')
+  echo "Current running version $VERSION_USED"
+  GREATEST=$(compare_versions "$VERSION_USED" "$ARMADILLO_VERSION_MINIMAL")
+  if [ "$GREATEST" = "$ARMADILLO_VERSION_MINIMAL" ]; then
+    echo "Current version is not upgradeable. It must be higher then $ARMADILLO_VERSION_MINIMAL"
     exit
-  }
   fi
-  
-  if [ "$VERSION_USED" != "$ARMADILLO_LATEST_VERSION" ]; then
-  {
-       
-          
-    DL_URL=https://github.com/molgenis/molgenis-service-armadillo/releases/download/v$ARMADILLO_LATEST_VERSION/molgenis-armadillo-$ARMADILLO_LATEST_VERSION.jar
-    
-    if validate_url "$DL_URL"; then
-      # Stop armadillo
-      systemctl stop armadillo
-      wget -q -O $ARMADILLO_PATH/application/armadillo-"$ARMADILLO_LATEST_VERSION".jar "$DL_URL"
-      ln -s -f $ARMADILLO_PATH/application/armadillo-"$ARMADILLO_LATEST_VERSION".jar $ARMADILLO_PATH/application/armadillo.jar
-      echo "armadillo $ARMADILLO_LATEST_VERSION updated"
-      systemctl start armadillo
 
+  NEXT_VERSION="$PINNED_VERSION"
+  if [ -z "$NEXT_VERSION" ]; then
+    # Check the remote latest available version
+    LATEST_RELEASE_URL=$ARMADILLO_GITHUB/releases/latest
+    echo "Checking for latest release: $LATEST_RELEASE_URL"
+    LATEST_RELEASE=$(curl --location --silent --header 'Accept: application/json' $LATEST_RELEASE_URL)
+
+    NEXT_VERSION=$(echo "$LATEST_RELEASE" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/' | sed -e s/.*v//)
+    echo "Latest release found $NEXT_VERSION"
+  fi
+
+  if [ "$PINNED_VERSION" != "$NEXT_VERSION" ]; then
+    GREATEST=$(compare_versions "$VERSION_USED" "$NEXT_VERSION")
+    if [ "$GREATEST" =  "$VERSION_USED" ]; then
+      echo "Current version $VERSION_USED is greater then $NEXT_VERSION ... skipping"
+      exit
     fi
-    
+  fi
+
+  DL_URL="$ARMADILLO_GITHUB/releases/download/v$NEXT_VERSION/molgenis-armadillo-$NEXT_VERSION.jar"
+
+  if validate_url "$DL_URL"; then
+  {
+    # Skip on dev
+    [ $MODE = "dev" ] || systemctl stop armadillo
+
+    DOWNLOAD_DESTINATION_JAR="$ARMADILLO_PATH/application/armadillo-$NEXT_VERSION.jar"
+    if [[ -f "$DOWNLOAD_DESTINATION_JAR" ]]; then
+      echo "File already downloaded"
+    else
+      echo "Downloading $DOWNLOAD_DESTINATION_JAR"
+      wget -q -O "$DOWNLOAD_DESTINATION_JAR" "$DL_URL"
+    fi
+
+    if [ "$AUTO_INSTALL" = "y" ]; then
+      ln -s -f $DOWNLOAD_DESTINATION_JAR $ARMADILLO_PATH/application/armadillo.jar
+      echo "armadillo $NEXT_VERSION updated"
+    fi
+
+    # Skip on dev
+    [ $MODE = "dev" ] || systemctl start armadillo
   }
   else
-  {
-    echo "No armadillo updates found"
-  }
+    echo "Somehow $DL_URL is not a valid page."
   fi
-
 
 }
 
@@ -55,6 +109,30 @@ function validate_url(){
   fi
 }
 
+# Return greatest of a.b.c and x.y.z
+# Example 1.2.3 < 2.1.0 return 2.1.0
+#
+# GREATEST=$(compare_versions "3.4.0" "4.0.0")
+# echo "Greatest $GREATEST"
+compare_versions() {
+  # We split the inputs on the dot '.' as an array '()'
+  local IFS=.
+  # shellcheck disable=SC2206
+  local -a ver1=($1)
+  # shellcheck disable=SC2206
+  local -a ver2=($2)
+
+  for i in {0..2}; do
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      echo "$1"
+      return
+    elif ((10#${ver1[i]} < 10#${ver2[i]})); then
+      echo "$2"
+      return
+    fi
+  done
+  echo "$1"
+}
 
 
 check_armadillo_update


### PR DESCRIPTION
Changed the script:

- added echo's to see what vars/url are found and used
- added `mode=dev` or `non dev` to run `systemctl`
- added argument to download `pre-release` versions or older then `4.0.0.` versions
- auto install is possible (default:n)
- added version compare

## Test locally

- checkout repo
- `./gradlew run`
- `cd scripts/install`
- `./armadillo-check-update.sh`
- `./armadillo-check-update.sh 3.3.0`

## Test on server

- change mode to prd
- check armadillo path for valid and application downloads
- check value of auto install
- `./armadillo-check-update.sh`
- `./armadillo-check-update.sh 3.3.0`
