### PR TITLE
fix(docs): make docs available for anonymous

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
@@ -63,6 +63,7 @@ public class AuthConfig {
             requests
                 .requestMatchers(
                     "/",
+                    "/_docs/**",
                     "/info",
                     "/index.html",
                     "/logout",


### PR DESCRIPTION
When login to Armadillo docs worked fine ... never tested it anonymous which redirected to OIDC .. that is now fixed