### PR TITLE
bug: cicd should use local image

### DIFF
--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,29 +1,33 @@
 # Continue integration
 
+The CICD makes use of the `docker compose` [armadillo-compose](./armadillo-compose.md)
+build in [`build/docker/armadillo-compose`](../../build/docker/armadillo-compose)
+together with an R image capable of running `release-test.R`.
+
 ## Preparation
 
 From the project [root](../../) directory run
 
 ```bash
 ./gradlew clean build docker
+```
+
+This creates `Dockerfile` and Armadillo JAR in `build/docker`.
+
+```bash
 ./docker/bin/prepare.bash ci
 ```
 
-This creates the needed Armadillo JAR file, images and needed files in [build/docker](../../build/docker/).
+This creates `armadillo-compose/` and `cicd/` trees in [build/docker](../../build/docker/).
 
-- [build/docker/armadillo-compose](../../build/docker/armadillo-compose/) for running stand alone and CICD
-- [build/docker/cicd](../../build/docker/cicd)
+- [build/docker/armadillo-compose](../../build/docker/armadillo-compose/) for running Armadillo demo and used by CICD.
+- [build/docker/cicd](../../build/docker/cicd) for running the `release-test.R` script.
 - Note [build/docker/cicd/](../../build/docker/cicd) which hold an `armadillo/` tree needed for `release-test.R` to run properly.
 
 ```bash
-find build/docker
+find ./build/docker
 # if available
-tree build/docker
-```
-
-and
-```bash
-docker image ls
+tree ./build/docker
 ```
 
 ## Changing settings
@@ -36,29 +40,31 @@ In this directory [docker/ci](.) directory:
 
 If needed check available images defined in `application.yml` and `docker-compose.yml` match.
 
-```bash
-docker images ls
-```
+## Run Armadillo and profiles
 
-should list
-
-- molgenis/molgenis-armadillo (required)
-- datashield/rock-base (depends)
-- datashield/rock-dolomite-xenon (depends)
-- molgenis/r-cicd (required)
-
-
-### Run Armadillo and profiles
-
-From with in [build/docker/armadillo-compos](../../build/docker/armadillo-compose/) run
+From within [build/docker/armadillo-compos](../../build/docker/armadillo-compose) run
 
 ```bash
-docker compose down
-# Later stop with CTRL-C
+# First time build new image
+docker compose build
+# Use CTRL-C to stop
 docker compose up
 ```
 
 In same directory you can:
+
+- check running images
+
+```bash
+docker compose images
+```
+
+should list
+
+- `molgenis/molgenis-armadillo` (required)
+- `datashield/rock-base` (depends)
+- `datashield/rock-dolomite-xenon` (depends)
+- `molgenis/r-cicd` (required)
 
 - check status
 

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       args:
         JAR_FILE: '*.jar'
 
-    image: molgenis/molgenis-armadillo:latest
+    image: molgenis/molgenis-armadillo:local
     environment:
       LOGGING_CONFIG: 'classpath:logback-file.xml'
       AUDIT_LOG_PATH: '/app/logs/audit.log'


### PR DESCRIPTION
Fixes #660

It seems using a different image tag should fix this ... using `:local` in `armadillo-compose` config.

```yml
    image: molgenis/molgenis-armadillo:local
```

It does not work on MacOS (SegFault) so let's see what CICD does