### PR TITLE
fix(demo): relative path

### DIFF
--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       AUDIT_LOG_PATH: '/app/logs/audit.log'
       SPRING_SECURITY_USER_PASSWORD: 'admin'
     volumes:
-      - ${PWD}/armadillo/logs:/logs
-      - ${PWD}/armadillo/data:/data
-      - ${PWD}/armadillo/config:/config
+      - ./armadillo/logs:/logs
+      - ./armadillo/data:/data
+      - ./armadillo/config:/config
       - /var/run/docker.sock:/var/run/docker.sock
 
   default:


### PR DESCRIPTION
Trying to run the demo set in armadillo-compose.zip Linux users have to run using sudo and got error for `${PWD}` in `docker-compose.yml`

> WARN[0000] The "PWD" variable is not set. Defaulting to a blank string.