### PR TITLE
chore: gradle/add upgrade checker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ As we now have the option to download the logfile from the application we need t
 ./gradlew wrapper --gradle-version 8.6
 ```
 
+## Check for updates
+
+To get a list of new dependencies run
+
+```bash
+./gradlew dependencyUpdates
+```
+
 ## Tools
 
 We use intellij to develop

--- a/application.template.yml
+++ b/application.template.yml
@@ -29,8 +29,6 @@ spring:
 #          molgenis:
 #            client-id: '...'
 #            client-secret: '...'
-#            authorization-grant-types:
-#              - refresh_token
 #      resourceserver:
 #        jwt:
 #          issuer-uri: 'http://auth.molgenis.org'

--- a/application.template.yml
+++ b/application.template.yml
@@ -29,6 +29,8 @@ spring:
 #          molgenis:
 #            client-id: '...'
 #            client-secret: '...'
+#            authorization-grant-types:
+#              - refresh_token
 #      resourceserver:
 #        jwt:
 #          issuer-uri: 'http://auth.molgenis.org'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id 'application'
     id "jacoco"
     id 'com.palantir.docker' version '0.35.0'
+    id 'com.github.ben-manes.versions' version '0.50.0'
 }
 
 targetCompatibility = '17'


### PR DESCRIPTION
This plugin https://github.com/ben-manes/gradle-versions-plugin adds command `https://github.com/ben-manes/gradle-versions-plugin`

It prints and builds in `cat build/dependencyUpdates/report.txt`

Currently this gives

```txt

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.c4-soft.springaddons:spring-security-oauth2-test-webmvc-addons:4.5.1
 - com.google.auto.value:auto-value:1.10.4
 - com.google.auto.value:auto-value-annotations:1.10.4
 - com.google.code.gson:gson:2.10.1
 - io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4
 - io.swagger.core.v3:swagger-annotations:2.2.20
 - junit:junit:4.13.2
 - org.apache.hadoop:hadoop-client:3.3.6
 - org.jacoco:org.jacoco.agent:0.8.8
 - org.jacoco:org.jacoco.ant:0.8.8
 - org.mockito:mockito-inline:5.2.0
 - org.rosuda.REngine:REngine:2.1.0
 - org.rosuda.REngine:Rserve:1.8.1

The following dependencies have later milestone versions:
 - com.diffplug.spotless:com.diffplug.spotless.gradle.plugin [6.15.0 -> 6.25.0]
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.50.0 -> 0.51.0]
 - com.github.docker-java:docker-java [3.3.4 -> 3.3.6]
     https://github.com/docker-java/docker-java
 - com.github.docker-java:docker-java-transport-zerodep [3.3.4 -> 3.3.6]
     https://github.com/docker-java/docker-java
 - com.github.node-gradle.node:com.github.node-gradle.node.gradle.plugin [3.5.1 -> 7.0.2]
 - com.google.guava:guava [31.1-jre -> 33.0.0-jre]
     https://github.com/google/guava
 - com.kohlschutter.junixsocket:junixsocket-common [2.3.3 -> 2.9.0]
     https://kohlschutter.github.io/junixsocket/
 - com.kohlschutter.junixsocket:junixsocket-native-common [2.3.3 -> 2.9.0]
     https://kohlschutter.github.io/junixsocket/
 - com.palantir.docker:com.palantir.docker.gradle.plugin [0.35.0 -> 0.36.0]
 - commons-io:commons-io [2.11.0 -> 2.15.1]
     https://commons.apache.org/proper/commons-io/
 - io.micrometer:micrometer-registry-prometheus [1.11.5 -> 1.12.4]
     https://github.com/micrometer-metrics/micrometer
 - jakarta.validation:jakarta.validation-api [3.0.2 -> 3.1.0-M1]
     https://beanvalidation.org
 - net.logstash.logback:logstash-logback-encoder [7.2 -> 7.4]
     https://github.com/logfellow/logstash-logback-encoder
 - org.apache.commons:commons-text [1.10.0 -> 1.11.0]
     https://commons.apache.org/proper/commons-text
 - org.apache.parquet:parquet-hadoop [1.12.3 -> 1.13.1]
     https://parquet.apache.org
 - org.json:json [20230227 -> 20240303]
     https://github.com/douglascrockford/JSON-java
 - org.obiba.datashield:ds4j-core [2.0.0 -> 2.1.0]
 - org.obiba.datashield:ds4j-r [2.0.0 -> 2.1.0]
 - org.sonarqube:org.sonarqube.gradle.plugin [3.5.0.2730 -> 4.4.1.3373]
 - org.springdoc:springdoc-openapi-starter-webmvc-ui [2.1.0 -> 2.3.0]
     https://springdoc.org/
 - org.springframework:spring-aspects [6.0.13 -> 6.1.4]
     https://github.com/spring-projects/spring-framework
 - org.springframework.boot:org.springframework.boot.gradle.plugin [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-configuration-processor [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-actuator [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-json [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-security [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-test [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-validation [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-web [3.1.5 -> 3.2.3]
     https://spring.io/projects/spring-boot
 - org.springframework.retry:spring-retry [2.0.4 -> 2.0.5]
     https://www.springsource.org
 - org.springframework.security:spring-security-core [6.1.5 -> 6.2.2]
     https://spring.io/projects/spring-security
 - org.springframework.security:spring-security-oauth2-client [6.1.5 -> 6.2.2]
     https://spring.io/projects/spring-security
 - org.springframework.security:spring-security-oauth2-jose [6.1.5 -> 6.2.2]
     https://spring.io/projects/spring-security
 - org.springframework.security:spring-security-oauth2-resource-server [6.1.5 -> 6.2.2]
     https://spring.io/projects/spring-security
 - org.springframework.security:spring-security-test [6.1.5 -> 6.2.2]
     https://spring.io/projects/spring-security

Gradle release-candidate updates:
 - Gradle: [7.6.4 -> 8.6 -> 8.7-rc-3]
```