### PR TITLE
chore: sonar output is missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
                 test \
                 jacocoMergedReport \
                 sonar \
+                  -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password \
                   -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io -Dsonar.verbose=true \
                   -Dsonar.pullrequest.key=${CIRCLE_PULL_REQUEST##*/} -Dsonar.pullrequest.branch=${CIRCLE_BRANCH} \
                 dockerPush

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -89,7 +89,9 @@ test {
 
 jacocoTestReport {
     reports {
-        xml.required
+        xml.required = true
+        csv.required = false
+        html.required = false
     }
     dependsOn test
 }

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -16,6 +16,8 @@ repositories {
     }
 }
 
+bootJar.enabled = false
+
 dependencies {
     //internal
     implementation project(':r')
@@ -68,13 +70,6 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.10.4"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required
-    }
-    dependsOn test
-}
-
 test {
     useJUnitPlatform()
     maxParallelForks = Runtime.runtime.availableProcessors() / 2
@@ -92,10 +87,17 @@ test {
     finalizedBy jacocoTestReport
 }
 
+jacocoTestReport {
+    reports {
+        xml.required
+    }
+    dependsOn test
+}
+
 spotless {
     java {
         googleJavaFormat('1.15.0')
     }
 }
+
 build.dependsOn spotlessApply
-bootJar.enabled = false

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -92,7 +92,6 @@ jacocoTestReport {
         xml.required
     }
     dependsOn test
-    dependsOn spotlessApply
 }
 
 spotless {

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -92,6 +92,7 @@ jacocoTestReport {
         xml.required
     }
     dependsOn test
+    dependsOn spotlessApply
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,8 @@ docker {
 dockerPrepare.dependsOn bootJar
 
 //merge test reports
-test.dependsOn subprojects.test
 task jacocoMergedReport(type: JacocoReport) {
-    dependsOn test
+    dependsOn subprojects.test
     additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     classDirectories.setFrom files(subprojects.sourceSets.main.output)

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ task jacocoMergedReport(type: JacocoReport) {
     classDirectories.setFrom files(subprojects.sourceSets.main.output)
     executionData.setFrom project.fileTree(dir: '.', include: '**/build/jacoco/test.exec')
     reports {
-        xml.required
+        xml.required = true
         csv.required = false
         html.required = false
     }
@@ -165,6 +165,8 @@ task jacocoMergedReport(type: JacocoReport) {
 //push to sonarqube
 sonarqube {
     properties {
+        // Uncomment when upgrading to sonar 5.x
+        // property 'sonar.gradle.skipCompile', 'true'
         property 'sonar.projectName', 'armadillo-service'
         property 'sonar.projectKey', 'org.molgenis:armadillo-service'
         property 'sonar.coverage.jacoco.xmlReportPaths', "${projectDir}/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -144,13 +144,9 @@ docker {
 dockerPrepare.dependsOn bootJar
 
 //merge test reports
+test.dependsOn subprojects.test
 task jacocoMergedReport(type: JacocoReport) {
-    dependsOn project.getTasksByName(":armadillo:test", true)
-    dependsOn project.getTasksByName(":r:test", true)
-    dependsOn project.getTasksByName("jacocoTestReport", true)
-    dependsOn project.getTasksByName("jacocoTestReport", true)
-    dependsOn project.getTasksByName("bootStartScripts", true)
-    dependsOn project.getTasksByName("startScripts", true)
+    dependsOn test
     additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     classDirectories.setFrom files(subprojects.sourceSets.main.output)

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,12 @@ dockerPrepare.dependsOn bootJar
 
 //merge test reports
 task jacocoMergedReport(type: JacocoReport) {
-    dependsOn subprojects.test
+    dependsOn project.getTasksByName(":armadillo:test", true)
+    dependsOn project.getTasksByName(":r:test", true)
+    dependsOn project.getTasksByName("jacocoTestReport", true)
+    dependsOn project.getTasksByName("jacocoTestReport", true)
+    dependsOn project.getTasksByName("bootStartScripts", true)
+    dependsOn project.getTasksByName("startScripts", true)
     additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
     classDirectories.setFrom files(subprojects.sourceSets.main.output)

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,8 @@ task jacocoMergedReport(type: JacocoReport) {
     executionData.setFrom project.fileTree(dir: '.', include: '**/build/jacoco/test.exec')
     reports {
         xml.required
+        csv.required = false
+        html.required = false
     }
 }
 

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -69,8 +69,6 @@ jacocoTestReport {
         xml.required
     }
     dependsOn test
-    dependsOn spotlessApply
-
 }
 
 spotless {

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -66,7 +66,9 @@ test {
 
 jacocoTestReport {
     reports {
-        xml.required
+        xml.required = true
+        csv.required = false
+        html.required = false
     }
     dependsOn test
 }

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -69,6 +69,8 @@ jacocoTestReport {
         xml.required
     }
     dependsOn test
+    dependsOn spotlessApply
+
 }
 
 spotless {

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -46,14 +46,6 @@ dependencies {
     //annotation
     annotationProcessor "com.google.auto.value:auto-value:1.10.4"
 }
-build.dependsOn spotlessApply
-
-jacocoTestReport {
-    reports {
-        xml.required
-    }
-    dependsOn test
-}
 
 test {
     useJUnitPlatform()
@@ -72,8 +64,17 @@ test {
     finalizedBy jacocoTestReport
 }
 
+jacocoTestReport {
+    reports {
+        xml.required
+    }
+    dependsOn test
+}
+
 spotless {
     java {
         googleJavaFormat('1.15.0')
     }
 }
+
+build.dependsOn spotlessApply


### PR DESCRIPTION
We saw notices in CDCD log on step **build, test, push docker**

Both PRs below have same related log ... guess not generating a report could make next sonar step fail.

> Task :jacocoTestReport SKIPPED

## This PR #695

> The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.

> No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml


```log
> Task :r:jacocoTestReport
> Task :bootStartScripts
> Task :jacocoTestReport SKIPPED <=========
> Task :startScripts
> Task :jacocoMergedReport

> Task :sonar
The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml

> Task :dockerClean
> Task :dockerPrepare
```

## Other PR ie #698

```
> Task :r:jacocoTestReport
> Task :bootStartScripts
> Task :jacocoTestReport SKIPPED <==========
> Task :startScripts
> Task :jacocoMergedReport

> Task :sonar
The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='/root/repo/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml

> Task :dockerClean
> Task :dockerPrepare
```