### PR TITLE
feat: add autostart profiles

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -123,6 +123,7 @@ public class DevelopmentController {
     whitelist.add(pkg);
     ProfileConfig profileConfig =
         ProfileConfig.create(
+            currentConfig.getAutoStart(),
             currentConfig.getName(),
             currentConfig.getImage(),
             currentConfig.getHost(),

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
@@ -13,6 +13,8 @@ import org.molgenis.armadillo.profile.ContainerInfo;
 @AutoValue
 @JsonInclude(Include.NON_NULL)
 public abstract class ProfileResponse {
+  public abstract boolean getAutoStart();
+
   public abstract String getName();
 
   @Nullable // only required when docker enabled
@@ -34,6 +36,7 @@ public abstract class ProfileResponse {
 
   public static ProfileResponse create(ProfileConfig profileConfig, ContainerInfo containerInfo) {
     return new AutoValue_ProfileResponse(
+        profileConfig.getAutoStart(),
         profileConfig.getName(),
         profileConfig.getImage(),
         profileConfig.getHost(),

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
@@ -149,7 +149,13 @@ public class ProfilesController {
   @ResponseStatus(NO_CONTENT)
   public void profileUpsert(Principal principal, @Valid @RequestBody ProfileConfig profileConfig) {
     auditor.audit(
-        () -> profiles.upsert(profileConfig),
+        () -> {
+          profiles.upsert(profileConfig);
+          // FIXME: cannot call here (Caused by:
+          // com.github.dockerjava.api.exception.ConflictException: Status 409: {"message":"removal
+          // of container xenon is already in progress"})
+          // dockerService.doAutoStart();
+        },
         principal,
         UPSERT_PROFILE,
         Map.of(PROFILE, profileConfig));

--- a/armadillo/src/main/java/org/molgenis/armadillo/interceptor/ProfileAutoStartListener.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/interceptor/ProfileAutoStartListener.java
@@ -19,6 +19,8 @@ public class ProfileAutoStartListener implements ApplicationListener<ContextRefr
 
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
+    // FIXME: cannot call from here (security context not set)
+    // dockerService.doAutoStart();
     long delay = 5 * 1000;
     Map<String, ContainerInfo> allProfiles =
         RunAs.runAsSystem(() -> dockerService.getAllProfileStatuses());

--- a/armadillo/src/main/java/org/molgenis/armadillo/interceptor/ProfileAutoStartListener.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/interceptor/ProfileAutoStartListener.java
@@ -1,0 +1,39 @@
+package org.molgenis.armadillo.interceptor;
+
+import java.util.Map;
+import org.molgenis.armadillo.metadata.ProfileService;
+import org.molgenis.armadillo.profile.ContainerInfo;
+import org.molgenis.armadillo.profile.DockerService;
+import org.molgenis.armadillo.security.RunAs;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfileAutoStartListener implements ApplicationListener<ContextRefreshedEvent> {
+
+  @Autowired private DockerService dockerService;
+
+  @Autowired private ProfileService profileService;
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    long delay = 5 * 1000;
+    Map<String, ContainerInfo> allProfiles =
+        RunAs.runAsSystem(() -> dockerService.getAllProfileStatuses());
+    for (Map.Entry<String, ContainerInfo> entry : allProfiles.entrySet()) {
+      String key = entry.getKey();
+      ContainerInfo value = entry.getValue();
+
+      // You can now use the key and value.
+      System.out.println("Auto starting :" + " Key: " + key + ", Value: " + value);
+      try {
+        Thread.sleep(delay);
+      } catch (InterruptedException e) {
+        System.out.println("SLEEP ".repeat(10) + "exception");
+      }
+      RunAs.runAsSystem(() -> dockerService.startProfile(key));
+    }
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
@@ -10,6 +10,7 @@ import java.util.Set;
  * without setters.
  */
 public class InitialProfileConfig {
+  private boolean autoStart;
   private String name;
   private String image;
   private String host;
@@ -20,7 +21,11 @@ public class InitialProfileConfig {
 
   public ProfileConfig toProfileConfig() {
     return ProfileConfig.create(
-        name, image, host, port, packageWhitelist, functionBlacklist, options);
+        autoStart, name, image, host, port, packageWhitelist, functionBlacklist, options);
+  }
+
+  public void setAutoStart(boolean autoStart) {
+    this.autoStart = autoStart;
   }
 
   public void setName(String name) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
@@ -16,6 +16,9 @@ import org.molgenis.r.config.EnvironmentConfigProps;
 @AutoValue
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class ProfileConfig {
+  @JsonProperty("autoStart")
+  public abstract boolean getAutoStart();
+
   @JsonProperty("name")
   @NotEmpty
   public abstract String getName();
@@ -44,6 +47,7 @@ public abstract class ProfileConfig {
 
   @JsonCreator
   public static ProfileConfig create(
+      @JsonProperty("autoStart") boolean newAutoStart,
       @JsonProperty("name") String newName,
       @JsonProperty("image") String newImage,
       @JsonProperty("host") String newHost,
@@ -52,6 +56,7 @@ public abstract class ProfileConfig {
       @JsonProperty("functionBlacklist") Set<String> newFunctionBlacklist,
       @JsonProperty("options") Map<String, String> newOptions) {
     return new AutoValue_ProfileConfig(
+        newAutoStart,
         newName,
         newImage,
         newHost != null ? newHost : "localhost",
@@ -64,6 +69,7 @@ public abstract class ProfileConfig {
   @JsonCreator
   public static ProfileConfig createDefault() {
     return create(
+        true,
         "default",
         "datashield/armadillo-rserver",
         "localhost",

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -58,6 +58,7 @@ public class ProfileService {
         .put(
             profileName,
             ProfileConfig.create(
+                profileConfig.getAutoStart(),
                 profileName,
                 profileConfig.getImage(),
                 profileConfig.getHost(),

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -23,6 +23,7 @@ import org.molgenis.armadillo.exceptions.*;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
 import org.molgenis.armadillo.metadata.ProfileStatus;
+import org.molgenis.armadillo.security.RunAs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,6 +50,22 @@ public class DockerService {
   public DockerService(DockerClient dockerClient, ProfileService profileService) {
     this.dockerClient = dockerClient;
     this.profileService = profileService;
+  }
+
+  public void doAutoStart() {
+    profileService.getAll().stream()
+        .filter(ProfileConfig::getAutoStart)
+        .forEach(
+            profileConfig -> {
+              long delay = 5 * 1000;
+              RunAs.runAsSystem(() -> this.startProfile(profileConfig.getName()));
+              try {
+                System.out.println("SLEEPING ".repeat(10));
+                Thread.sleep(delay);
+              } catch (InterruptedException e) {
+                System.out.println("SLEEP ".repeat(10) + "exception");
+              }
+            });
   }
 
   public Map<String, ContainerInfo> getAllProfileStatuses() {

--- a/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
@@ -40,7 +40,7 @@ class DataShieldOptionsImplTest {
         ImmutableMap.of("a", "overrideA", "c", "overrideC");
     ProfileConfig profileConfig =
         ProfileConfig.create(
-            "dummy", "dummy", "localhost", 6311, Set.of(), emptySet(), configOptions);
+            true, "dummy", "dummy", "localhost", 6311, Set.of(), emptySet(), configOptions);
     options = new DataShieldOptionsImpl(profileConfig, packageService);
     ImmutableMap<String, String> packageOptions = ImmutableMap.of("a", "defaultA", "b", "defaultB");
     doReturn(rConnection).when(rConnectionFactory).tryCreateConnection();

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -240,7 +240,8 @@ class CommandsImplTest {
   void testSelectProfileWritesToSession() {
     RequestContextHolder.setRequestAttributes(attrs);
     ProfileConfig profileConfig =
-        ProfileConfig.create("exposome", "dummy", "localhost", 6311, Set.of(), Set.of(), Map.of());
+        ProfileConfig.create(
+            true, "exposome", "dummy", "localhost", 6311, Set.of(), Set.of(), Map.of());
     when(profileService.getByName("exposome")).thenReturn(profileConfig);
     commands.selectProfile("exposome");
     verify(attrs).setAttribute("profile", "exposome", SCOPE_SESSION);

--- a/armadillo/src/test/java/org/molgenis/armadillo/config/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/config/DockerServiceTest.java
@@ -144,6 +144,7 @@ class DockerServiceTest {
     var profile1 = ProfileConfig.createDefault();
     var profile2 =
         ProfileConfig.create(
+            false,
             "omics",
             "datashield/armadillo-rserver-omics",
             "localhost",

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -38,9 +38,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 class ProfilesControllerTest extends ArmadilloControllerTestBase {
 
   public static final String DEFAULT_PROFILE =
-      "{\"name\":\"default\",\"image\":\"datashield/armadillo-rserver:6.2.0\",\"port\":6311,\"packageWhitelist\":[\"dsBase\"],\"options\":{}}";
+      "{\"autoStart\":true,\"name\":\"default\",\"image\":\"datashield/armadillo-rserver:6.2.0\",\"port\":6311,\"packageWhitelist\":[\"dsBase\"],\"options\":{}}";
   public static final String OMICS_PROFILE =
-      "{\"name\":\"omics\",\"image\":\"datashield/armadillo-rserver-omics\",\"port\":6312,\"packageWhitelist\":[\"dsBase\", \"dsOmics\"],\"options\":{}}";
+      "{\"autoStart\":true,\"name\":\"omics\",\"image\":\"datashield/armadillo-rserver-omics\",\"port\":6312,\"packageWhitelist\":[\"dsBase\", \"dsOmics\"],\"options\":{}}";
 
   @Autowired ProfileService profileService;
   @MockBean ArmadilloStorageService armadilloStorage;
@@ -61,6 +61,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
         .put(
             "default",
             ProfileConfig.create(
+                true,
                 "default",
                 "datashield/armadillo-rserver:6.2.0",
                 "localhost",
@@ -73,6 +74,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
         .put(
             "omics",
             ProfileConfig.create(
+                true,
                 "omics",
                 "datashield/armadillo-rserver-omics",
                 "localhost",
@@ -103,7 +105,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
         .andExpect(
             content()
                 .json(
-                    "{\"name\":\"default\",\"image\":\"datashield/armadillo-rserver:6.2.0\",\"port\":6311,\"packageWhitelist\":[\"dsBase\"]}"));
+                    "{\"autoStart\":true,\"name\":\"default\",\"image\":\"datashield/armadillo-rserver:6.2.0\",\"port\":6311,\"packageWhitelist\":[\"dsBase\"]}"));
   }
 
   @Test
@@ -111,6 +113,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
   void profiles_PUT() throws Exception {
     ProfileConfig profileConfig =
         ProfileConfig.create(
+            false,
             "dummy",
             "dummy/armadillo:2.0.0",
             "localhost",

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
@@ -24,7 +24,7 @@ class ProfileServiceTest {
     var profilesMetadata = ProfilesMetadata.create();
     var defaultProfile =
         ProfileConfig.create(
-            "default", "test", "localhost", 1234, new HashSet<>(), Set.of(), new HashMap<>());
+            true, "default", "test", "localhost", 1234, new HashSet<>(), Set.of(), new HashMap<>());
     profilesMetadata.getProfiles().put("default", defaultProfile);
     var profilesLoader = new DummyProfilesLoader(profilesMetadata);
     var profileService = new ProfileService(profilesLoader, initialProfileConfigs, profileScope);

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -54,6 +54,7 @@ export type Principal = {
 };
 
 export type Profile = {
+  autoStart: boolean;
   name: string;
   image: string;
   host: string;

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -256,6 +256,7 @@ export default defineComponent({
     },
     profilesDataStructure(): TypeObject {
       let columns: TypeObject = {
+        autoStart: "boolean",
         name: "string",
         image: "string",
         host: "string",
@@ -394,6 +395,7 @@ export default defineComponent({
       this.clearUserMessages();
 
       this.profiles.unshift({
+        autoStart: true,
         name: "",
         image: "datashield/rock-base:latest",
         host: "localhost",

--- a/ui/tests/unit/views/Profiles.spec.ts
+++ b/ui/tests/unit/views/Profiles.spec.ts
@@ -53,6 +53,7 @@ describe("Profiles", () => {
         };
 
         default_profile_not_running = {
+            autoStart: true,
             name: "default",
             image: "datashield/rock-base:version",
             host: "localhost",
@@ -78,6 +79,7 @@ describe("Profiles", () => {
 
         singleTestData = [
             {
+                autoStart: true,
                 name: "profile-one",
                 image: "source/some_profile-one:version-one",
                 host: "localhost",
@@ -107,6 +109,7 @@ describe("Profiles", () => {
         });
 
         profileToAdd = {
+            autoStart: true,
             name: "profile-two",
             image: "other_source/profile-two:version-two",
             host: "localhost",


### PR DESCRIPTION
## Task

- [x] Add field `Auto start` to profile
- [ ] Make true/false a similar looking as field `admin` on users page
- [ ] When ✅ start container if not running
- [ ] When not ✅ do not stop running container
- [ ] On startup check container status and start those with `autostart==true`
  - The sketchy start all [`interceptor/ProfileAutoStartListener.java`](https://github.com/molgenis/molgenis-service-armadillo/pull/698#diff-e006b9b277ffe4ca179fe1e3f60f5fa4c3b8228e9bbce8a625c80a62c305a11b) make application startup delay much ... not sure that's a server problem but on MacOS it takes plus 20 seconds.
 

### Using docker

Docker has [restart policies](https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy)

Using `--restart`

- `no (default)`
- `on-failure[:max-retries]`
- `always`
- `unless-stopped`

Running `docker container inspect xenon` we currently have the **no** policy

```json
...
            "RestartPolicy": {
                "Name": "no",
                "MaximumRetryCount": 0
            },
...
```


After adding policy

```
docker container inspect default xenon | jq ".[] | [.Name, .HostConfig.RestartPolicy.Name]"
[
  "/default",
  "unless-stopped"
]
[
  "/xenon",
  "unless-stopped"
]
```