### PR TITLE
chore: add update tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,23 @@ As we now have the option to download the logfile from the application we need t
 ./gradlew test
 ```
 
+## Upgrade plugins
+
+Use the commands listed below.
+
+```bash
+./gradlew useLatestVersions
+./gradlew useLatestVersionsCheck
+```
+
+Some plugins need manually editing the build files.
+
+To help find the right `build.gradle` use the command below with your keyword.
+
+```bash
+find . -type f -name "build.gradle" -exec echo {} \; -exec grep YOUR_KEY_WORD {}  \;
+```
+
 ## Upgrading gradle
 
 ```bash

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'com.github.docker-java:docker-java:3.3.6'
     implementation 'com.github.docker-java:docker-java-transport-zerodep:3.3.6'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
-    implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
+    implementation 'org.apache.parquet:parquet-hadoop:1.13.1'
     implementation 'org.apache.hadoop:hadoop-client:3.3.6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.spring.dependency-management'
     id "jacoco"
     id "java"
-    id "com.diffplug.spotless" version "6.15.0"
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 repositories {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
     implementation 'org.obiba.datashield:ds4j-core:2.0.0'
     implementation 'org.obiba.datashield:ds4j-r:2.0.0'
-    implementation 'com.github.docker-java:docker-java:3.3.4'
-    implementation 'com.github.docker-java:docker-java-transport-zerodep:3.3.4'
+    implementation 'com.github.docker-java:docker-java:3.3.6'
+    implementation 'com.github.docker-java:docker-java-transport-zerodep:3.3.6'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
     implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
     implementation 'org.apache.hadoop:hadoop-client:3.3.6'
@@ -57,8 +57,8 @@ dependencies {
 
     //Overrides docker-java's sub-dependency to fix compatibility issues with apple ARM chips
     //https://github.com/docker-java/docker-java/issues/1876 -->
-    implementation 'com.kohlschutter.junixsocket:junixsocket-common:2.3.3'
-    implementation 'com.kohlschutter.junixsocket:junixsocket-native-common:2.3.3'
+    implementation 'com.kohlschutter.junixsocket:junixsocket-common:2.9.0'
+    implementation 'com.kohlschutter.junixsocket:junixsocket-native-common:2.9.0'
 
     //test outside spring
     testImplementation 'com.c4-soft.springaddons:spring-security-oauth2-test-webmvc-addons:4.5.1'

--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.12.4'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework:spring-aspects'
@@ -46,14 +46,14 @@ dependencies {
     implementation 'org.rosuda.REngine:Rserve:1.8.1'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.20'
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
-    implementation 'org.obiba.datashield:ds4j-core:2.0.0'
-    implementation 'org.obiba.datashield:ds4j-r:2.0.0'
+    implementation 'org.obiba.datashield:ds4j-core:2.1.0'
+    implementation 'org.obiba.datashield:ds4j-r:2.1.0'
     implementation 'com.github.docker-java:docker-java:3.3.6'
     implementation 'com.github.docker-java:docker-java-transport-zerodep:3.3.6'
-    implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
     implementation 'org.apache.hadoop:hadoop-client:3.3.6'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 
     //Overrides docker-java's sub-dependency to fix compatibility issues with apple ARM chips
     //https://github.com/docker-java/docker-java/issues/1876 -->

--- a/build.gradle
+++ b/build.gradle
@@ -12,15 +12,16 @@
  * - ui/build.gradle
  */
 plugins {
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.3'
     id "io.spring.dependency-management" version "1.1.4"
     id "java"
-    id "org.sonarqube" version "3.5.0.2730"
+    id "org.sonarqube" version "4.4.1.3373"
     id 'maven-publish'
     id 'application'
     id "jacoco"
-    id 'com.palantir.docker' version '0.35.0'
-    id 'com.github.ben-manes.versions' version '0.50.0'
+    id 'com.palantir.docker' version '0.36.0'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
+    id 'com.github.ben-manes.versions' version '0.51.0'
 }
 
 targetCompatibility = '17'

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     implementation 'org.rosuda.REngine:Rserve:1.8.1'
     implementation 'com.google.guava:guava:33.1.0-jre'
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'org.json:json:20230227'
+    implementation 'org.apache.commons:commons-text:1.11.0'
+    implementation 'org.json:json:20240303'
 
     //test
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "jacoco"
     id "java"
-    id "com.diffplug.spotless" version "6.15.0"
+    id "com.diffplug.spotless" version "6.25.0"
     id 'org.springframework.boot'
     id 'io.spring.dependency-management'
 }
@@ -18,7 +18,7 @@ bootJar.enabled = false
 dependencies {
     //spring
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'jakarta.validation:jakarta.validation-api'
+    implementation 'jakarta.validation:jakarta.validation-api:3.1.0-M1'
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.retry:spring-retry'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -28,10 +28,10 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
 
     //other
-    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'commons-io:commons-io:2.15.1'
     implementation 'org.rosuda.REngine:REngine:2.1.0'
     implementation 'org.rosuda.REngine:Rserve:1.8.1'
-    implementation 'com.google.guava:guava:31.1-jre'
+    implementation 'com.google.guava:guava:33.1.0-jre'
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.json:json:20230227'

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "base"
-    id "com.github.node-gradle.node" version "3.5.1"
+    id "com.github.node-gradle.node" version "7.0.2"
 }
 
 def nodeSpec = {


### PR DESCRIPTION
This tool mentioned upgrade sonar so let's see what CICD tells

See #695 


### Steps taken

Install plugin `se.patrikerdes.use-latest-versions`

Run repeatedly

```bash
./gradlew useLatestVersions
./gradlew useLatestVersionsCheck

# For easier reading
# ./gradlew useLatestVersions | grep -A 20 "The following dependencies have later milestone versions:"
# ./gradlew useLatestVersionsCheck | grep -A 10 "Task :useLatestVersionsCheck FAILED"
```
and manually upgrade mentions items

```bash
find . -type f -name "build.gradle" -exec echo {} \; -exec grep YOUR_KEY_WORD {}  \;
```