### PR TITLE
Add restart policy for profiles

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.RestartPolicy;
 import jakarta.ws.rs.ProcessingException;
 import java.net.SocketException;
 import java.util.List;
@@ -158,7 +159,10 @@ public class DockerService {
     portBindings.bind(exposed, Ports.Binding.bindPort(profileConfig.getPort()));
     try (CreateContainerCmd cmd = dockerClient.createContainerCmd(profileConfig.getImage())) {
       cmd.withExposedPorts(exposed)
-          .withHostConfig(new HostConfig().withPortBindings(portBindings))
+          .withHostConfig(
+              new HostConfig()
+                  .withPortBindings(portBindings)
+                  .withRestartPolicy(RestartPolicy.unlessStoppedRestart()))
           .withName(profileConfig.getName())
           .withEnv("DEBUG=FALSE")
           .exec();


### PR DESCRIPTION
This uses Docker to restart profiles after a system reboot.

This makes PR #698 obsolete.

Local testing shows **unless-stopped** which seems a logical policy: if server restarts docker restarts **not stopped by a data manager** containers

```bash
docker container inspect default xenon | jq ".[] | [.Name, .HostConfig.RestartPolicy.Name]"
[
  "/default",
  "unless-stopped"
]
[
  "/xenon",
  "unless-stopped"
]
```