### PR TITLE
chore: remove spinner from resource upload

### DIFF
--- a/scripts/release/test-cases/upload-resource.R
+++ b/scripts/release/test-cases/upload-resource.R
@@ -10,7 +10,6 @@ post_resource_to_api <- function(project, key, auth_type, file, folder, name, ur
   ))
 
   # Run spinner while waiting for response
-  ansi_with_hidden_cursor(run_spinner(spinner))
   # Response will come when ready
   response <- value(api_call)
   # Set do_run_spinner to false, causing the spinner to stop running, see spin_till_done method


### PR DESCRIPTION
how to test:
- Rerun the release test up to and including line 88 (`upload_resource`)
