### PR TITLE
fix: info endpoint returns incorrect number of columns for linkfile

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloLinkFile.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloLinkFile.java
@@ -118,6 +118,10 @@ public class ArmadilloLinkFile {
     return this.project;
   }
 
+  public Integer getNumberOfVariables() {
+    return getVariables().split(",").length;
+  }
+
   public JsonObject loadFromStream(InputStream inputStream) {
     return JsonParser.parseReader(new InputStreamReader(inputStream)).getAsJsonObject();
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -219,7 +219,7 @@ public class LocalStorageService implements StorageService {
         objectName,
         fileSizeWithUnit,
         tableDimensions.get("rows"),
-        tableDimensions.get("columns"),
+        String.valueOf(linkFile.getNumberOfVariables()),
         linkFile.getSourceProject() + "/" + linkFile.getSourceObject(),
         linkFile.getVariables().split(","));
   }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloLinkFileTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloLinkFileTest.java
@@ -41,6 +41,12 @@ public class ArmadilloLinkFileTest {
   }
 
   @Test
+  public void testGetNumberOfVariables() {
+    Integer actual = alf.getNumberOfVariables();
+    assertEquals(3, actual);
+  }
+
+  @Test
   public void testLoadFromStream() {
     InputStream inputStream = new ByteArrayInputStream(testData.getBytes());
     JsonObject actual = alf.loadFromStream(inputStream);


### PR DESCRIPTION
how to test:
- create a link
- see that the number of columns in the preview is the same as the number of variables selected

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
