### PR TITLE
fix: #124 throw error when workspace too big to store on device

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
@@ -1,0 +1,31 @@
+package org.molgenis.armadillo.storage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.molgenis.armadillo.exceptions.StorageException;
+
+public class ArmadilloWorkspace {
+  byte[] content;
+
+  public ArmadilloWorkspace(InputStream is) {
+    content = toByteArray(is);
+  }
+
+  private byte[] toByteArray(InputStream is) {
+    try {
+      return IOUtils.toByteArray(is);
+    } catch (IOException e) {
+      throw new StorageException("Unable to read workspace");
+    }
+  }
+
+  public long getSize() {
+    return content.length;
+  }
+
+  public ByteArrayInputStream createInputStream() {
+    return new ByteArrayInputStream(content);
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -218,10 +218,6 @@ public class LocalStorageService implements StorageService {
       }
     } catch (IOException e) {
       throw new StorageException("Cannot retrieve size of file.");
-    } finally {
-      if (is != null) {
-        is.close();
-      }
     }
     return size;
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -208,18 +208,8 @@ public class LocalStorageService implements StorageService {
     return new ArmadilloLinkFile(armadilloLinkFileStream, bucketName, objectName);
   }
 
-  public long getSizeOfInputStream(InputStream is) throws IOException {
-    long size = 0;
-    int chunk;
-    try {
-      byte[] buffer = new byte[1024];
-      while ((chunk = is.read(buffer)) != -1) {
-        size += chunk;
-      }
-    } catch (IOException e) {
-      throw new StorageException("Cannot retrieve size of file.");
-    }
-    return size;
+  public ArmadilloWorkspace getWorkSpace(InputStream is) {
+    return new ArmadilloWorkspace(is);
   }
 
   private FileInfo getFileInfoForLinkFile(

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -208,6 +208,24 @@ public class LocalStorageService implements StorageService {
     return new ArmadilloLinkFile(armadilloLinkFileStream, bucketName, objectName);
   }
 
+  public long getSizeOfInputStream(InputStream is) throws IOException {
+    long size = 0;
+    int chunk;
+    try {
+      byte[] buffer = new byte[1024];
+      while ((chunk = is.read(buffer)) != -1) {
+        size += chunk;
+      }
+    } catch (IOException e) {
+      throw new StorageException("Cannot retrieve size of file.");
+    } finally {
+      if (is != null) {
+        is.close();
+      }
+    }
+    return size;
+  }
+
   private FileInfo getFileInfoForLinkFile(
       String bucketName, String objectName, String fileSizeWithUnit) throws FileNotFoundException {
     ArmadilloLinkFile linkFile = getArmadilloLinkFileFromName(bucketName, objectName);

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
@@ -39,8 +39,6 @@ public interface StorageService {
 
   Path getPathIfObjectExists(String bucketName, String objectName);
 
-  long getSizeOfInputStream(InputStream is) throws IOException;
-
   static String getHumanReadableByteCount(long bytes) {
     long absB = bytes == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(bytes);
     if (absB < 1024) {
@@ -56,4 +54,6 @@ public interface StorageService {
     Locale.setDefault(Locale.US);
     return String.format("%.1f %cB", value / 1024.0, ci.current());
   }
+
+  ArmadilloWorkspace getWorkSpace(InputStream is);
 }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
@@ -34,5 +34,7 @@ public interface StorageService {
 
   void delete(String bucketName, String objectName);
 
-  public Path getPathIfObjectExists(String bucketName, String objectName);
+  Path getPathIfObjectExists(String bucketName, String objectName);
+
+  long getSizeOfInputStream(InputStream is) throws IOException;
 }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/StorageService.java
@@ -3,7 +3,10 @@ package org.molgenis.armadillo.storage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.springframework.http.MediaType;
 
@@ -37,4 +40,20 @@ public interface StorageService {
   Path getPathIfObjectExists(String bucketName, String objectName);
 
   long getSizeOfInputStream(InputStream is) throws IOException;
+
+  static String getHumanReadableByteCount(long bytes) {
+    long absB = bytes == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(bytes);
+    if (absB < 1024) {
+      return bytes + " B";
+    }
+    long value = absB;
+    CharacterIterator ci = new StringCharacterIterator("KMGTPE");
+    for (int i = 40; i >= 0 && absB > 0xfffccccccccccccL >> i; i -= 10) {
+      value >>= 10;
+      ci.next();
+    }
+    value *= Long.signum(bytes);
+    Locale.setDefault(Locale.US);
+    return String.format("%.1f %cB", value / 1024.0, ci.current());
+  }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -10,10 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.molgenis.armadillo.storage.ArmadilloStorageService.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
@@ -502,23 +499,21 @@ class ArmadilloStorageServiceTest {
 
   @Test
   void testSaveWorkspace() {
+    ArmadilloWorkspace workspaceMock = mock(ArmadilloWorkspace.class);
+    ByteArrayInputStream isMock = mock(ByteArrayInputStream.class);
     when(principal.getName()).thenReturn("henk");
-
+    when(storageService.getWorkSpace(is)).thenReturn(workspaceMock);
+    when(workspaceMock.getSize()).thenReturn(12345L);
+    when(workspaceMock.createInputStream()).thenReturn(isMock);
     armadilloStorage.saveWorkspace(is, principal, "test");
-
-    verify(storageService).save(is, "user-henk", "test.RData", APPLICATION_OCTET_STREAM);
+    verify(storageService).save(isMock, "user-henk", "test.RData", APPLICATION_OCTET_STREAM);
   }
 
   @Test
-  void testSaveWorkspaceReturnsErrorWhenTooBig() throws IOException {
-    when(storageService.getSizeOfInputStream(is)).thenReturn(123456789123456789L);
-    assertThrows(
-        StorageException.class, () -> armadilloStorage.saveWorkspace(is, principal, "test"));
-  }
-
-  @Test
-  void testSaveWorkspaceReturnsErrorWhenCantDetermineSize() throws IOException {
-    when(storageService.getSizeOfInputStream(is)).thenThrow(IOException.class);
+  void testSaveWorkspaceReturnsErrorWhenTooBig() {
+    ArmadilloWorkspace workspaceMock = mock(ArmadilloWorkspace.class);
+    when(storageService.getWorkSpace(is)).thenReturn(workspaceMock);
+    when(workspaceMock.getSize()).thenReturn(123456789123456789L);
     assertThrows(
         StorageException.class, () -> armadilloStorage.saveWorkspace(is, principal, "test"));
   }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -520,8 +520,10 @@ class ArmadilloStorageServiceTest {
 
   @Test
   void testSaveWorkspaceChecksBucketName() {
+    ArmadilloWorkspace workspaceMock = mock(ArmadilloWorkspace.class);
     when(principal.getName()).thenReturn("Henk");
-
+    when(storageService.getWorkSpace(is)).thenReturn(workspaceMock);
+    when(workspaceMock.getSize()).thenReturn(12345L);
     assertThrows(
         IllegalArgumentException.class,
         () -> armadilloStorage.saveWorkspace(is, principal, "test"));

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -510,6 +510,20 @@ class ArmadilloStorageServiceTest {
   }
 
   @Test
+  void testSaveWorkspaceReturnsErrorWhenTooBig() throws IOException {
+    when(storageService.getSizeOfInputStream(is)).thenReturn(123456789123456789L);
+    assertThrows(
+        StorageException.class, () -> armadilloStorage.saveWorkspace(is, principal, "test"));
+  }
+
+  @Test
+  void testSaveWorkspaceReturnsErrorWhenCantDetermineSize() throws IOException {
+    when(storageService.getSizeOfInputStream(is)).thenThrow(IOException.class);
+    assertThrows(
+        StorageException.class, () -> armadilloStorage.saveWorkspace(is, principal, "test"));
+  }
+
+  @Test
   void testSaveWorkspaceChecksBucketName() {
     when(principal.getName()).thenReturn("Henk");
 

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
@@ -1,0 +1,31 @@
+package org.molgenis.armadillo.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.molgenis.armadillo.exceptions.StorageException;
+
+public class ArmadilloWorkspaceTest {
+  @Test
+  public void testGetFileName() {
+    InputStream stubInputStream =
+        IOUtils.toInputStream("some test data for my input stream", "UTF-8");
+    ArmadilloWorkspace workspace = new ArmadilloWorkspace(stubInputStream);
+    long size = workspace.getSize();
+    assertEquals(34, size);
+  }
+
+  @Test
+  void testGetByteOfInputStreamThrowsError() throws IOException {
+    InputStream isMock = mock(InputStream.class);
+    when(isMock.read(any(byte[].class))).thenThrow(IOException.class);
+    assertThrows(StorageException.class, () -> new ArmadilloWorkspace(isMock));
+  }
+}

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
@@ -14,7 +14,7 @@ import org.molgenis.armadillo.exceptions.StorageException;
 
 public class ArmadilloWorkspaceTest {
   @Test
-  public void testGetFileName() {
+  void testGetFileName() {
     InputStream stubInputStream =
         IOUtils.toInputStream("some test data for my input stream", "UTF-8");
     ArmadilloWorkspace workspace = new ArmadilloWorkspace(stubInputStream);

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
@@ -11,7 +11,6 @@ import static org.molgenis.armadillo.storage.StorageService.getHumanReadableByte
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -21,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -349,21 +347,6 @@ class LocalStorageServiceTest {
     Path path = localStorageService.getObjectPathSafely(bucket, object);
     mockedParquetUtils.verify(() -> ParquetUtils.previewRecords(path, 10, 10, new String[0]));
     mockedParquetUtils.close();
-  }
-
-  @Test
-  void testGetSizeOfInputStream() throws IOException {
-    InputStream stubInputStream =
-        IOUtils.toInputStream("some test data for my input stream", "UTF-8");
-    long size = localStorageService.getSizeOfInputStream(stubInputStream);
-    assertEquals(34, size);
-  }
-
-  @Test
-  void testGetSizeOfInputStreamThrowsError() throws IOException {
-    InputStream isMock = mock(InputStream.class);
-    when(isMock.read(any(byte[].class))).thenThrow(IOException.class);
-    assertThrows(StorageException.class, () -> localStorageService.getSizeOfInputStream(isMock));
   }
 
   @Test

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
+import static org.molgenis.armadillo.storage.StorageService.getHumanReadableByteCount;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -363,5 +364,23 @@ class LocalStorageServiceTest {
     InputStream isMock = mock(InputStream.class);
     when(isMock.read(any(byte[].class))).thenThrow(IOException.class);
     assertThrows(StorageException.class, () -> localStorageService.getSizeOfInputStream(isMock));
+  }
+
+  @Test
+  void testGetHumanReadableByteCountKb() {
+    String size = getHumanReadableByteCount(1234);
+    assertEquals("1.2 KB", size);
+  }
+
+  @Test
+  void testGetHumanReadableByteCountMb() {
+    String size = getHumanReadableByteCount(12345678);
+    assertEquals("11.8 MB", size);
+  }
+
+  @Test
+  void testGetHumanReadableByteCountGb() {
+    String size = getHumanReadableByteCount(12345678910L);
+    assertEquals("11.5 GB", size);
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/LocalStorageServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +20,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -346,5 +348,20 @@ class LocalStorageServiceTest {
     Path path = localStorageService.getObjectPathSafely(bucket, object);
     mockedParquetUtils.verify(() -> ParquetUtils.previewRecords(path, 10, 10, new String[0]));
     mockedParquetUtils.close();
+  }
+
+  @Test
+  void testGetSizeOfInputStream() throws IOException {
+    InputStream stubInputStream =
+        IOUtils.toInputStream("some test data for my input stream", "UTF-8");
+    long size = localStorageService.getSizeOfInputStream(stubInputStream);
+    assertEquals(34, size);
+  }
+
+  @Test
+  void testGetSizeOfInputStreamThrowsError() throws IOException {
+    InputStream isMock = mock(InputStream.class);
+    when(isMock.read(any(byte[].class))).thenThrow(IOException.class);
+    assertThrows(StorageException.class, () -> localStorageService.getSizeOfInputStream(isMock));
   }
 }


### PR DESCRIPTION
Testing this is incredibly annoying. I tested it on the dev server and it kept dying, we really need to look into that. Maybe we should just trust that I've tested it, and just do the code review, if not, here is how I tested it:

How to test:
On the devserver, I put the build version of this PR, it's called `armadillo-workspace-4.x-SNAPSHOT.jar`
Check the version of armadillo on the devserver by going there in the browser and see what version is presented in the top menu, if it's not 4.3-SNAPSHOT (we have to investigate why my new build results in 4.3), then it's the incorrect version. To fix the version, ssh to demo server as root (see serverlist for IP)
``` bash
cd /usr/share/armadillo/application
service armadillo stop
rm armadillo.jar
ln -s armadillo-workspace-4.x-SNAPSHOT.jar armadillo.jar
service armadillo start
```
Check if server is back up. Open R studio. Create a script that creates a decently sized workspace:
``` R
library(MolgenisArmadillo)
library(DSMolgenisArmadillo)
library(dsBaseClient)
library(DSI)
demo_url <- "https://dev-armadillo.molgenis.org/"
demo_token <- armadillo.get_token(demo_url)

builder <- DSI::newDSLoginBuilder()

builder$append(
  server = "armadillo",
  url = demo_url,
  profile = "xenon",
  driver = "ArmadilloDriver",
  token = demo_token
)

logindata <- builder$build()

conns <- DSI::datashield.login(logins = logindata, assign = F)

datashield.assign.table(conns, "nonrep", "lifecycle/core/nonrep")

fit <- ds.glmSLMA(
  formula = "preg_no ~ 1+ height_mes_m + preg_fever + preg_gain_mes + ethn1_p + weight_f1 + smk_p + death_child_age",
  family = "gaussian",
  newobj = "test",
  dataName = "nonrep")


for (i in 1:1000) {
  ds.assign("test", paste0("test", i))
}


datashield.workspace_save(conns, "test_save")
```
Go to the data folder on the server to check if the workspace was saved properly:
```bash
cd /usr/share/armadillo/data
ls
```
cd to the `user-....` dir
``` bash
ls -la
```
You should see, something like:
`-rw-r--r-- 1 armadillo armadillo 296008668 May 23 12:50 armadillo:test_save.RData`

Now logout and reload the workspace:
``` R
datashield.logout(conns)

conns <- datashield.login(logindata, restore = "test_save")
ds.ls()
```
Should get many many objects.

Now open the browser, go to the "Insight" tab, select "Server metrics" and search for "free".  Check how much diskspace is left. Open your terminal again, where you still should be logged in to the server as root. Create a file that is the free diskspace - 500MB:
```
fallocate -l 5.2g /usr/share/armadillo/data/test.img
```
If you get a message with no space left on device, please immediately remove the file again and create a smaller one:
```
rm /usr/share/armadillo/data/test.img
```
Go to the browser, see the error message appearing that there's only a small amount of diskspace left. It should be less than 550MBs, but more than 0 bytes! If it's 0 bytes, quickly remove the file and retry because the profile might crash.

Open the logs on the server:
`tail -1000f /var/log/armadillo/armadillo.log`

Open R studio and save workspace again:
```
datashield.workspace_save(conns, "test_save")
```

This takes a while, but when it's done, check the logs, you should see something like:
```
024-05-23 14:33:00.816 [pool-2-thread-2|] INFO  o.m.armadillo.audit.AuditLogger - AuditEvent [timestamp=2024-05-23T14:33:00.814920662Z, principal=m.k.slofstra@umcg.nl, type=SAVE_USER_WORKSPACE_FAILURE, data={id=armadillo:test_save, sessionId=07B1ACE84E5AA51F922B4D2C8F251BF1, message=org.molgenis.r.exceptions.RExecutionException: org.molgenis.armadillo.exceptions.StorageException: Can't save workspace: workspace too big (282.1 MB), not enough space left on device. Try to make your workspace smaller and/or contact the administrator to increase diskspace., type=java.util.concurrent.CompletionException, roles=[ROLE_SU]}]
```

Now cd back to the data folder and verify the workspace is still the last saved version of it (time should be last time you saved and not your current try) and it should still be the same size.

We now need to catch this exception in the DSMolgenisArmadillo package. 

todo:
- [ ] updated docs in case of new feature (docs: https://github.com/molgenis/molgenis-r-datashield/pull/74)
- [x] added tests
