### PR TITLE
fix: throw proper error message when workspace over 2GBs

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
@@ -223,6 +223,17 @@ public class ArmadilloStorageService {
         .build();
   }
 
+  private void trySaveWorkspace (ArmadilloWorkspace workspace, Principal principal, String id) {
+    try {
+      storageService.save(
+              workspace.createInputStream(),
+              getUserBucketName(principal),
+              getWorkspaceObjectName(id),
+              APPLICATION_OCTET_STREAM);
+    } catch (StorageException e) {
+      throw new StorageException(e);
+    }
+  }
   public void saveWorkspace(InputStream is, Principal principal, String id) {
     // Load root dir
     File drive = new File("/");
@@ -231,15 +242,7 @@ public class ArmadilloStorageService {
       ArmadilloWorkspace workspace = storageService.getWorkSpace(is);
       long fileSize = workspace.getSize();
       if (usableSpace > fileSize * 2L) {
-        try {
-          storageService.save(
-                  workspace.createInputStream(),
-                  getUserBucketName(principal),
-                  getWorkspaceObjectName(id),
-                  APPLICATION_OCTET_STREAM);
-        } catch (StorageException e) {
-          throw new StorageException(e);
-        }
+        trySaveWorkspace(workspace, principal, id);
       } else {
         throw new StorageException(
                 format(

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
@@ -227,24 +227,27 @@ public class ArmadilloStorageService {
     // Load root dir
     File drive = new File("/");
     long usableSpace = drive.getUsableSpace();
-
-    ArmadilloWorkspace workspace = storageService.getWorkSpace(is);
-    long fileSize = workspace.getSize();
-    if (usableSpace > fileSize * 2L) {
-      try {
-        storageService.save(
-            workspace.createInputStream(),
-            getUserBucketName(principal),
-            getWorkspaceObjectName(id),
-            APPLICATION_OCTET_STREAM);
-      } catch (StorageException e) {
-        throw new StorageException(e);
+    try {
+      ArmadilloWorkspace workspace = storageService.getWorkSpace(is);
+      long fileSize = workspace.getSize();
+      if (usableSpace > fileSize * 2L) {
+        try {
+          storageService.save(
+                  workspace.createInputStream(),
+                  getUserBucketName(principal),
+                  getWorkspaceObjectName(id),
+                  APPLICATION_OCTET_STREAM);
+        } catch (StorageException e) {
+          throw new StorageException(e);
+        }
+      } else {
+        throw new StorageException(
+                format(
+                        "Can't save workspace: workspace too big (%s), not enough space left on device. Try to make your workspace smaller and/or contact the administrator to increase diskspace.",
+                        getHumanReadableByteCount(fileSize)));
       }
-    } else {
-      throw new StorageException(
-          format(
-              "Can't save workspace: workspace too big (%s), not enough space left on device. Try to make your workspace smaller and/or contact the administrator to increase diskspace.",
-              getHumanReadableByteCount(fileSize)));
+    } catch (StorageException e) {
+      throw new StorageException(e.getMessage().replace("load", "save"));
     }
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
@@ -7,7 +7,7 @@ import org.molgenis.armadillo.exceptions.StorageException;
 
 public class ArmadilloWorkspace {
   byte[] content;
-  public static final String workspaceTooBigError = "Unable to load workspace. Maximum supported workspace size is 2GB";
+  public static final String WORKSPACE_TOO_BIG_ERROR = "Unable to load workspace. Maximum supported workspace size is 2GB";
 
   public ArmadilloWorkspace(InputStream is) {
     content = toByteArray(is);
@@ -17,7 +17,7 @@ public class ArmadilloWorkspace {
     try {
       return IOUtils.toByteArray(is);
     } catch (OutOfMemoryError e) {
-      throw new StorageException(workspaceTooBigError);
+      throw new StorageException(WORKSPACE_TOO_BIG_ERROR);
     } catch (Exception e) {
       throw new StorageException("Unable to load workspace, because: " + e);
     }

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
@@ -1,14 +1,13 @@
 package org.molgenis.armadillo.storage;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.molgenis.armadillo.exceptions.StorageException;
 
 public class ArmadilloWorkspace {
   byte[] content;
-  public static String workspaceTooBigError = "Unable to load workspace. Maximum supported workspace size is 2GB";
+  public static final String workspaceTooBigError = "Unable to load workspace. Maximum supported workspace size is 2GB";
 
   public ArmadilloWorkspace(InputStream is) {
     content = toByteArray(is);

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloWorkspace.java
@@ -8,6 +8,7 @@ import org.molgenis.armadillo.exceptions.StorageException;
 
 public class ArmadilloWorkspace {
   byte[] content;
+  public static String workspaceTooBigError = "Unable to load workspace. Maximum supported workspace size is 2GB";
 
   public ArmadilloWorkspace(InputStream is) {
     content = toByteArray(is);
@@ -16,8 +17,10 @@ public class ArmadilloWorkspace {
   private byte[] toByteArray(InputStream is) {
     try {
       return IOUtils.toByteArray(is);
-    } catch (IOException e) {
-      throw new StorageException("Unable to read workspace");
+    } catch (OutOfMemoryError e) {
+      throw new StorageException(workspaceTooBigError);
+    } catch (Exception e) {
+      throw new StorageException("Unable to load workspace, because: " + e);
     }
   }
 

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -519,6 +519,16 @@ class ArmadilloStorageServiceTest {
   }
 
   @Test
+  void testSaveWorkspaceReturnsErrorWhenBiggerThan2Gbs() {
+    when(storageService.getWorkSpace(is)).thenThrow(new StorageException(ArmadilloWorkspace.workspaceTooBigError));
+    try {
+      armadilloStorage.saveWorkspace(is, principal, "test");
+    } catch (StorageException e) {
+      assertEquals("Unable to save workspace. Maximum supported workspace size is 2GB", e.getMessage());
+    }
+  }
+
+  @Test
   void testSaveWorkspaceChecksBucketName() {
     ArmadilloWorkspace workspaceMock = mock(ArmadilloWorkspace.class);
     when(principal.getName()).thenReturn("Henk");

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -520,7 +520,7 @@ class ArmadilloStorageServiceTest {
 
   @Test
   void testSaveWorkspaceReturnsErrorWhenBiggerThan2Gbs() {
-    when(storageService.getWorkSpace(is)).thenThrow(new StorageException(ArmadilloWorkspace.workspaceTooBigError));
+    when(storageService.getWorkSpace(is)).thenThrow(new StorageException(ArmadilloWorkspace.WORKSPACE_TOO_BIG_ERROR));
     try {
       armadilloStorage.saveWorkspace(is, principal, "test");
     } catch (StorageException e) {

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
@@ -36,7 +36,7 @@ public class ArmadilloWorkspaceTest {
     try {
       new ArmadilloWorkspace(isMock);
     } catch(StorageException e) {
-      assertEquals(ArmadilloWorkspace.workspaceTooBigError, e.getMessage());
+      assertEquals(ArmadilloWorkspace.WORKSPACE_TOO_BIG_ERROR, e.getMessage());
     }
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloWorkspaceTest.java
@@ -28,4 +28,15 @@ public class ArmadilloWorkspaceTest {
     when(isMock.read(any(byte[].class))).thenThrow(IOException.class);
     assertThrows(StorageException.class, () -> new ArmadilloWorkspace(isMock));
   }
+
+  @Test
+  void testGetByteOfInputStreamThrowsMemoryError() throws IOException {
+    InputStream isMock = mock(InputStream.class);
+    when(isMock.read(any(byte[].class))).thenThrow(OutOfMemoryError.class);
+    try {
+      new ArmadilloWorkspace(isMock);
+    } catch(StorageException e) {
+      assertEquals(ArmadilloWorkspace.workspaceTooBigError, e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
part of #772

how to test:
Run armadillo locally, then run in R:
``` R
library(MolgenisArmadillo)
library(DSMolgenisArmadillo)
library(dsBaseClient)
library(DSI)
demo_url <- "https://dev-armadillo.molgenis.org/"
demo_url <- "http://localhost:8080"
demo_token <- armadillo.get_token(demo_url)


builder <- DSI::newDSLoginBuilder()

builder$append(
  server = "armadillo",
  url = demo_url,
  profile = "xenon",
  driver = "ArmadilloDriver",
  token = demo_token
)


logindata <- builder$build()

conns <- DSI::datashield.login(logins = logindata, assign = T)

datashield.assign.table(conns, "nonrep", "lifecycle/core/nonrep")

fit <- ds.glmSLMA(
  formula = "preg_no ~ 1+ height_mes_m + preg_fever + preg_gain_mes + ethn1_p + weight_f1 + smk_p + death_child_age",
  family = "gaussian",
  newobj = "test",
  dataName = "nonrep")

start_time <- Sys.time()
for (i in 1:7000) {
  ds.assign("test", paste0("test", i))
  #silently_run(ds.assign("test", paste0("test", i)))
}
end_time <- Sys.time()
print(paste0("assigning took: ", end_time - start_time))

start_time <- Sys.time()
datashield.workspace_save(conns, "test_save4")
```
Look in the logs, see the error message tells the user that saving a workspace of more than 2GB is not possible.

Will have to fix the error getting through in R

todo:
- [ ] updated docs in case of new feature
- [x] added tests
