### PR TITLE
feat: expose actuator/prometheus endpoint

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
@@ -15,6 +15,8 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.stereotype.Component;
 
+import static org.molgenis.armadillo.security.RunAs.runAsSystem;
+
 @Component
 @Endpoint(id = "rserveProcesses")
 public class RProcessEndpoint {
@@ -40,18 +42,20 @@ public class RProcessEndpoint {
   }
 
   <T> T doWithConnection(String environmentName, Function<RServerConnection, T> action) {
-    var environment =
-        profileService.getAll().stream()
-            .filter(it -> environmentName.equals(it.getName()))
-            .map(ProfileConfig::toEnvironmentConfigProps)
-            .findFirst()
-            .orElseThrow();
-    RServerConnection connection = connect(environment);
-    try {
-      return action.apply(connection);
-    } finally {
-      connection.close();
-    }
+    return runAsSystem(() -> {
+      var environment =
+              profileService.getAll().stream()
+                      .filter(it -> environmentName.equals(it.getName()))
+                      .map(ProfileConfig::toEnvironmentConfigProps)
+                      .findFirst()
+                      .orElseThrow();
+      RServerConnection connection = connect(environment);
+      try {
+        return action.apply(connection);
+      } finally {
+        connection.close();
+      }
+    });
   }
 
   RServerConnection connect(EnvironmentConfigProps environment) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/info/RProcessEndpoint.java
@@ -42,20 +42,18 @@ public class RProcessEndpoint {
   }
 
   <T> T doWithConnection(String environmentName, Function<RServerConnection, T> action) {
-    return runAsSystem(() -> {
-      var environment =
-              profileService.getAll().stream()
-                      .filter(it -> environmentName.equals(it.getName()))
-                      .map(ProfileConfig::toEnvironmentConfigProps)
-                      .findFirst()
-                      .orElseThrow();
-      RServerConnection connection = connect(environment);
-      try {
-        return action.apply(connection);
-      } finally {
-        connection.close();
-      }
-    });
+    var environment =
+            runAsSystem(profileService::getAll).stream()
+            .filter(it -> environmentName.equals(it.getName()))
+            .map(ProfileConfig::toEnvironmentConfigProps)
+            .findFirst()
+            .orElseThrow();
+    RServerConnection connection = connect(environment);
+    try {
+      return action.apply(connection);
+    } finally {
+      connection.close();
+    }
   }
 
   RServerConnection connect(EnvironmentConfigProps environment) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
+@PreAuthorize("hasRole('ROLE_SU')")
 public class ProfileService {
 
   private final ProfilesLoader loader;
@@ -34,18 +35,15 @@ public class ProfileService {
    * Initialization separated from constructor so that it can be called in WebMvc tests
    * <strong>after</strong> mocks have been initialized.
    */
-  @PreAuthorize("hasRole('ROLE_SU')")
   public void initialize() {
     settings = loader.load();
     bootstrap();
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   public List<ProfileConfig> getAll() {
     return new ArrayList<>(settings.getProfiles().values());
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   public ProfileConfig getByName(String profileName) {
     if (!settings.getProfiles().containsKey(profileName)) {
       throw new UnknownProfileException(profileName);
@@ -53,7 +51,6 @@ public class ProfileService {
     return settings.getProfiles().get(profileName);
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   public void upsert(ProfileConfig profileConfig) {
     String profileName = profileConfig.getName();
     settings
@@ -73,14 +70,12 @@ public class ProfileService {
     save();
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   public void addToWhitelist(String profileName, String pack) {
     getByName(profileName).getPackageWhitelist().add(pack);
     flushProfileBeans(profileName);
     save();
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   public void delete(String profileName) {
     if (profileName.equals(DEFAULT)) {
       throw new DefaultProfileDeleteException();
@@ -91,17 +86,14 @@ public class ProfileService {
     save();
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   private void flushProfileBeans(String profileName) {
     profileScope.removeAllProfileBeans(profileName);
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   private void save() {
     settings = loader.save(settings);
   }
 
-  @PreAuthorize("hasRole('ROLE_SU')")
   private void bootstrap() {
     if (settings == null) {
       return;

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -13,7 +13,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
-@PreAuthorize("hasRole('ROLE_SU')")
 public class ProfileService {
 
   private final ProfilesLoader loader;
@@ -35,15 +34,18 @@ public class ProfileService {
    * Initialization separated from constructor so that it can be called in WebMvc tests
    * <strong>after</strong> mocks have been initialized.
    */
+  @PreAuthorize("hasRole('ROLE_SU')")
   public void initialize() {
     settings = loader.load();
     bootstrap();
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   public List<ProfileConfig> getAll() {
     return new ArrayList<>(settings.getProfiles().values());
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   public ProfileConfig getByName(String profileName) {
     if (!settings.getProfiles().containsKey(profileName)) {
       throw new UnknownProfileException(profileName);
@@ -51,6 +53,7 @@ public class ProfileService {
     return settings.getProfiles().get(profileName);
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   public void upsert(ProfileConfig profileConfig) {
     String profileName = profileConfig.getName();
     settings
@@ -70,12 +73,14 @@ public class ProfileService {
     save();
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   public void addToWhitelist(String profileName, String pack) {
     getByName(profileName).getPackageWhitelist().add(pack);
     flushProfileBeans(profileName);
     save();
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   public void delete(String profileName) {
     if (profileName.equals(DEFAULT)) {
       throw new DefaultProfileDeleteException();
@@ -86,14 +91,17 @@ public class ProfileService {
     save();
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   private void flushProfileBeans(String profileName) {
     profileScope.removeAllProfileBeans(profileName);
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   private void save() {
     settings = loader.save(settings);
   }
 
+  @PreAuthorize("hasRole('ROLE_SU')")
   private void bootstrap() {
     if (settings == null) {
       return;

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
@@ -75,6 +75,7 @@ public class AuthConfig {
                     "/v3/**",
                     "/swagger-ui/**",
                     "/ui/**",
+                    "/actuator/prometheus",
                     "/swagger-ui.html")
                 .permitAll()
                 .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class))


### PR DESCRIPTION
how to test:
- Start up armadillo
- Run this commandline: 
`curl 'http://localhost:8080/actuator/prometheus' -i -X GET`
No stacktraces will show up in the armadillo logs and the version of the R serve profiles are visible in the commandline output:
```
# HELP rserve_processes_current Current number of RServe processes on the R environment
# TYPE rserve_processes_current gauge
rserve_processes_current{environment="default",} 2.0
rserve_processes_current{environment="xenon",} 2.0
```

For code review:
- Check if this is secure enough. Removed pre authorise on class `ProfileService`, but put it back on all the methods of that class, so that the `.getAll` class can be called with `runAsSystem` in the `doWithConnection` method of `RProcessEndpoint`. I think that we don't leak anything that is not supposed to be leaked, but better to check twice. I'm for instance a bit worried about leakin the `seed`, but I think that that doesn't happen. 

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
