### PR TITLE
fix: #804 dont show preview and columns when in create linkfile view

### DIFF
--- a/ui/src/views/ProjectsExplorer.vue
+++ b/ui/src/views/ProjectsExplorer.vue
@@ -131,10 +131,12 @@
             </div>
             <div v-else-if="!loading_preview && !askIfPreviewIsEmpty()">
               <div class="text-end fst-italic">
-                Preview:
-                {{ `${selectedFile.replace(".parquet", "")}` }} ({{
-                  `${fileInfo.dataSizeRows}x${fileInfo.dataSizeColumns}`
-                }})
+                <span v-if="!createLinkFromSrc">
+                  Preview:
+                  {{ `${selectedFile.replace(".parquet", "")}` }} ({{
+                    `${fileInfo.dataSizeRows}x${fileInfo.dataSizeColumns}`
+                  }})
+                </span>
                 <div v-if="isLinkFileType(selectedFile)">
                   Linked from: {{ fileInfo.sourceLink }}
                 </div>
@@ -189,7 +191,7 @@
                 :n-rows="fileInfo.dataSizeRows"
               ></DataPreviewTable>
               <ColumnNamesPreview
-                v-if="!editView"
+                v-if="!editView && !createLinkFromSrc"
                 :columnNames="columnNames"
                 :buttonName="columnNames.length > 10 ? '+ ' + (columnNames.length - 10) + ' variables: ' : columnNames.length + ' variables: '"
               >


### PR DESCRIPTION
how to test:
- go to https://preview-armadillo-pr-806.dev.molgenis.org/
- go to a table
- click on the create view button in right top corner
- see that the "Preview" in the top corner disappears, as well as the columns in the bottom left of the view screen

Before:
![Screenshot 2024-10-15 at 16 05 12](https://github.com/user-attachments/assets/b9377443-f5eb-435c-8972-b6030fd8bd5a)

After:
![Screenshot 2024-10-15 at 16 05 30](https://github.com/user-attachments/assets/62597778-4e3d-4c74-b479-18cb5563ac58)
 

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
