### PR TITLE
fix: show link files

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/ArmadilloStorageService.java
@@ -160,7 +160,7 @@ public class ArmadilloStorageService {
   @PreAuthorize("hasAnyRole('ROLE_SU', 'ROLE_' + #project.toUpperCase() + '_RESEARCHER')")
   public List<String> listTables(String project) {
     return listObjects(project).stream()
-        .filter(it -> it.endsWith(PARQUET))
+        .filter(it -> it.endsWith(PARQUET) || it.endsWith(LINK_FILE))
         .map(FilenameUtils::removeExtension)
         .toList();
   }

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/ArmadilloStorageServiceTest.java
@@ -403,11 +403,29 @@ class ArmadilloStorageServiceTest {
 
   @Test
   @WithMockUser(roles = "GECKO_RESEARCHER")
-  void testListTablesListsObjectsInSharedBucket() {
+  void testListTablesListsParquetObjectsInSharedBucket() {
     when(storageService.listBuckets()).thenReturn(singletonList(SHARED_GECKO));
     when(storageService.listObjects(SHARED_GECKO)).thenReturn(List.of(item));
     when(item.name()).thenReturn("1_0_release_1_1/gecko.parquet");
     assertEquals(List.of("gecko/1_0_release_1_1/gecko"), armadilloStorage.listTables("gecko"));
+  }
+
+  @Test
+  @WithMockUser(roles = "GECKO_RESEARCHER")
+  void testListTablesListsAlfObjectsInSharedBucket() {
+    when(storageService.listBuckets()).thenReturn(singletonList(SHARED_GECKO));
+    when(storageService.listObjects(SHARED_GECKO)).thenReturn(List.of(item));
+    when(item.name()).thenReturn("1_0_release_1_1/gecko_link.alf");
+    assertEquals(List.of("gecko/1_0_release_1_1/gecko_link"), armadilloStorage.listTables("gecko"));
+  }
+
+  @Test
+  @WithMockUser(roles = "GECKO_RESEARCHER")
+  void testListTablesDoesntListCSVObjectsInSharedBucket() {
+    when(storageService.listBuckets()).thenReturn(singletonList(SHARED_GECKO));
+    when(storageService.listObjects(SHARED_GECKO)).thenReturn(List.of(item));
+    when(item.name()).thenReturn("1_0_release_1_1/gecko_link.csv");
+    assertEquals(List.of(), armadilloStorage.listTables("gecko"));
   }
 
   @Test


### PR DESCRIPTION
how to test:
- [ ] Code review
- [ ] Create a link file in the UI, login as a researcher, run `datashield.tables(conns)`, check that link file appears
- [ ] Create another file type (e.g. .csv), login as a researcher, run `datashield.tables(conns)`, and check that file does not appear
