### PR TITLE
fix: #833 documentation link not working

### DIFF
--- a/ui/src/components/Navbar.vue
+++ b/ui/src/components/Navbar.vue
@@ -15,7 +15,7 @@
           <a
             type="button"
             class="btn btn-dark"
-            href="/_docs/master/index.html"
+            href="https://molgenis.github.io/molgenis-service-armadillo/"
             target="_blank"
             ><i class="bi bi-book"></i> Docs</a
           >


### PR DESCRIPTION
how to test:
Open the preview, click on the docs link, see the docs are opened
https://preview-armadillo-pr-834.dev.molgenis.org/
