### PR TITLE
feat: Monitoring endpoint for getting versions and status of profiles

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
@@ -62,6 +62,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String DELETE_PROJECT = "DELETE_PROJECT";
   public static final String GET_PROJECT = "GET_PROJECT";
   public static final String LIST_PROFILES = "LIST_PROFILES";
+  public static final String LIST_PROFILES_STATUS = "LIST_PROFILES_STATUS";
   public static final String UPSERT_PROFILE = "UPSERT_PROFILE";
   public static final String DELETE_PROFILE = "DELETE_PROFILE";
   public static final String GET_PROFILE = "GET_PROFILE";
@@ -98,7 +99,6 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String TABLE = "table";
   public static final String ID = "id";
   public static final String USER = "user";
-  static final String ANONYMOUS = "ANONYMOUS";
   public static final String MDC_SESSION_ID = "sessionID";
   private ApplicationEventPublisher applicationEventPublisher;
   private Clock clock = Clock.systemUTC();

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
@@ -6,6 +6,7 @@ import static org.molgenis.armadillo.audit.AuditEventPublisher.GET_PROFILE;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.LIST_PROFILES;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.PROFILE;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.UPSERT_PROFILE;
+import static org.molgenis.armadillo.security.RunAs.runAsSystem;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -22,9 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.molgenis.armadillo.audit.AuditEventPublisher;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
@@ -50,6 +49,7 @@ public class ProfilesController {
   private final ProfileService profiles;
   private final DockerService dockerService;
   private final AuditEventPublisher auditor;
+  private final ProfileService profileService;
 
   public ProfilesController(
       ProfileService profileService,
@@ -58,6 +58,7 @@ public class ProfilesController {
     this.profiles = requireNonNull(profileService);
     this.dockerService = dockerService;
     this.auditor = requireNonNull(auditor);
+    this.profileService = profileService;
   }
 
   @Operation(
@@ -85,6 +86,50 @@ public class ProfilesController {
   @ResponseStatus(OK)
   public List<ProfileResponse> profileList(Principal principal) {
     return auditor.audit(this::getProfiles, principal, LIST_PROFILES);
+  }
+
+  @Operation(
+      summary = "List profiles",
+      description =
+          """
+                        If Docker management is enabled, this will also display each profile's Docker
+                        container status.
+                        """)
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "All profiles listed",
+            content =
+                @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = ProfileResponse.class))))
+      })
+  @GetMapping(value = "status", produces = APPLICATION_JSON_VALUE)
+  @ResponseStatus(OK)
+  public List<Map<String, String>> getProfileStatus(Principal principal) {
+    List<ProfileResponse> profiles = runAsSystem(this::getProfiles);
+    List<Map<String, String>> result = new ArrayList<>();
+    profiles.forEach(
+        (profile) -> {
+          Map<String, String> info = new HashMap<>();
+          String profileName = profile.getName();
+          String status = requireNonNull(profile.getContainer()).getStatus().toString();
+          info.put("status", status);
+          if (dockerService != null && Objects.equals(status, "RUNNING")) {
+            String[] config =
+                runAsSystem(() -> dockerService.getProfileEnvironmentConfig(profileName));
+            String versions =
+                Arrays.toString(
+                    Arrays.stream(config)
+                        .filter(configItem -> configItem.contains("_VERSION"))
+                        .toArray(String[]::new));
+            info.put("config", versions);
+          }
+          info.put("image", profile.getImage());
+          info.put("name", profileName);
+          result.add(info);
+        });
+    return result;
   }
 
   private List<ProfileResponse> getProfiles() {

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.DELETE_PROFILE;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.GET_PROFILE;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.LIST_PROFILES;
+import static org.molgenis.armadillo.audit.AuditEventPublisher.LIST_PROFILES_STATUS;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.PROFILE;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.UPSERT_PROFILE;
 import static org.molgenis.armadillo.security.RunAs.runAsSystem;
@@ -49,7 +50,6 @@ public class ProfilesController {
   private final ProfileService profiles;
   private final DockerService dockerService;
   private final AuditEventPublisher auditor;
-  private final ProfileService profileService;
 
   public ProfilesController(
       ProfileService profileService,
@@ -58,7 +58,6 @@ public class ProfilesController {
     this.profiles = requireNonNull(profileService);
     this.dockerService = dockerService;
     this.auditor = requireNonNull(auditor);
-    this.profileService = profileService;
   }
 
   @Operation(
@@ -107,6 +106,10 @@ public class ProfilesController {
   @GetMapping(value = "status", produces = APPLICATION_JSON_VALUE)
   @ResponseStatus(OK)
   public List<Map<String, String>> getProfileStatus(Principal principal) {
+    return auditor.audit(this::getDockerProfileInformation, principal, LIST_PROFILES_STATUS);
+  }
+
+  private List<Map<String, String>> getDockerProfileInformation() {
     List<ProfileResponse> profiles = runAsSystem(this::getProfiles);
     List<Map<String, String>> result = new ArrayList<>();
     profiles.forEach(

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesController.java
@@ -113,17 +113,23 @@ public class ProfilesController {
         (profile) -> {
           Map<String, String> info = new HashMap<>();
           String profileName = profile.getName();
-          String status = requireNonNull(profile.getContainer()).getStatus().toString();
-          info.put("status", status);
-          if (dockerService != null && Objects.equals(status, "RUNNING")) {
-            String[] config =
-                runAsSystem(() -> dockerService.getProfileEnvironmentConfig(profileName));
-            String versions =
-                Arrays.toString(
-                    Arrays.stream(config)
-                        .filter(configItem -> configItem.contains("_VERSION"))
-                        .toArray(String[]::new));
-            info.put("config", versions);
+          if (dockerService != null) {
+            String status =
+                runAsSystem(
+                    () -> dockerService.getProfileStatus(profileName).getStatus().toString());
+            info.put("status", status);
+            if (Objects.equals(status, "RUNNING")) {
+              String[] config =
+                  runAsSystem(() -> dockerService.getProfileEnvironmentConfig(profileName));
+              String versions =
+                  Arrays.toString(
+                      Arrays.stream(config)
+                          .filter(configItem -> configItem.contains("_VERSION"))
+                          .toArray(String[]::new));
+              info.put("config", versions);
+            } else {
+              info.put("config", "[]");
+            }
           }
           info.put("image", profile.getImage());
           info.put("name", profileName);

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesStatusResponse.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfilesStatusResponse.java
@@ -1,0 +1,30 @@
+package org.molgenis.armadillo.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonSerialize(as = ProfilesStatusResponse.class)
+public abstract class ProfilesStatusResponse {
+  @JsonProperty("image")
+  public abstract String image();
+
+  @JsonProperty("name")
+  public abstract String name();
+
+  @JsonProperty("config")
+  public abstract String config();
+
+  @JsonProperty("status")
+  public abstract String status();
+
+  public static ProfilesStatusResponse create(
+      String image, String name, String config, String status) {
+    return new AutoValue_ProfilesStatusResponse(image, name, config, status);
+  }
+
+  public static ProfilesStatusResponse create(String image, String name) {
+    return new AutoValue_ProfilesStatusResponse(image, name, "[]", "DOCKER_MANAGEMENT_DISABLED");
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -11,10 +11,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.*;
 import jakarta.ws.rs.ProcessingException;
 import java.net.SocketException;
 import java.util.List;
@@ -113,6 +110,13 @@ public class DockerService {
       return containerName.replace("armadillo-docker-compose-", "").replace("-1", "");
     }
     return containerName;
+  }
+
+  public String[] getProfileEnvironmentConfig(String profileName) {
+    profileService.getByName(profileName);
+    String containerName = asContainerName(profileName);
+    InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(containerName).exec();
+    return containerInfo.getConfig().getEnv();
   }
 
   public ContainerInfo getProfileStatus(String profileName) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/security/AuthConfig.java
@@ -75,6 +75,7 @@ public class AuthConfig {
                     "/v3/**",
                     "/swagger-ui/**",
                     "/ui/**",
+                    "/ds-profiles/status",
                     "/actuator/prometheus",
                     "/swagger-ui.html")
                 .permitAll()

--- a/armadillo/src/test/java/org/molgenis/armadillo/TestSecurityConfig.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/TestSecurityConfig.java
@@ -14,6 +14,9 @@ import org.molgenis.armadillo.metadata.ProfilesLoader;
 import org.molgenis.armadillo.profile.ProfileScope;
 import org.molgenis.armadillo.service.FileService;
 import org.molgenis.armadillo.storage.ArmadilloStorageService;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -35,7 +38,15 @@ public class TestSecurityConfig {
 
   @Bean
   protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
-    return http.authorizeHttpRequests(request -> request.anyRequest().authenticated())
+    return http.authorizeHttpRequests(
+            requests ->
+                requests
+                    .requestMatchers("/ds-profiles/status")
+                    .permitAll()
+                    .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class))
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
         .httpBasic(Customizer.withDefaults())
         .csrf(csrf -> csrf.disable())
         .build();

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
@@ -1,0 +1,83 @@
+package org.molgenis.armadillo.controller;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.mockito.Mockito.*;
+import static org.molgenis.armadillo.security.RunAs.runAsSystem;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.molgenis.armadillo.TestSecurityConfig;
+import org.molgenis.armadillo.metadata.*;
+import org.molgenis.armadillo.storage.ArmadilloStorageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+
+@WebMvcTest(ProfilesController.class)
+@Import({TestSecurityConfig.class})
+class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase {
+
+  @Autowired ProfileService profileService;
+  @MockBean ArmadilloStorageService armadilloStorage;
+  @MockBean ProfilesLoader profilesLoader;
+
+  @BeforeEach
+  public void before() {
+    var settings = createExampleSettings();
+    when(profilesLoader.load()).thenReturn(settings);
+    runAsSystem(() -> profileService.initialize());
+  }
+
+  private ProfilesMetadata createExampleSettings() {
+    var settings = ProfilesMetadata.create();
+    settings
+        .getProfiles()
+        .put(
+            "default",
+            ProfileConfig.create(
+                "default",
+                "datashield/armadillo-rserver:6.2.0",
+                "localhost",
+                6311,
+                Set.of("dsBase"),
+                emptySet(),
+                emptyMap()));
+    settings
+        .getProfiles()
+        .put(
+            "omics",
+            ProfileConfig.create(
+                "omics",
+                "datashield/armadillo-rserver-omics",
+                "localhost",
+                6312,
+                Set.of("dsBase", "dsOmics"),
+                emptySet(),
+                emptyMap()));
+    return settings;
+  }
+
+  @Test
+  @WithAnonymousUser
+  void getProfileStatusWithoutDocker_GET() throws Exception {
+    mockMvc
+        .perform(get("/ds-profiles/status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    "["
+                        + "{\"name\":\"default\",\"status\":\"DOCKER_MANAGEMENT_DISABLED\",\"config\":\"[]\",\"image\":\"datashield/armadillo-rserver:6.2.0\"},"
+                        + "{\"name\":\"omics\",\"status\":\"DOCKER_MANAGEMENT_DISABLED\",\"config\":\"[]\",\"image\":\"datashield/armadillo-rserver-omics\"}"
+                        + "]"));
+  }
+}

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
@@ -30,7 +30,7 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
   @MockBean ProfilesLoader profilesLoader;
 
   @BeforeEach
-  public void before() {
+  void before() {
     var settings = createExampleSettings();
     when(profilesLoader.load()).thenReturn(settings);
     runAsSystem(() -> profileService.initialize());

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
 @WebMvcTest(ProfilesController.class)
@@ -149,7 +150,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
   }
 
   @Test
-  @WithMockUser(roles = "SU")
+  @WithAnonymousUser
   void getProfileStatus_GET() throws Exception {
     ContainerInfo runningContainer = ContainerInfo.create(ProfileStatus.RUNNING);
     ContainerInfo offlineContainer = ContainerInfo.create(ProfileStatus.DOCKER_OFFLINE);

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -150,7 +150,6 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
   @Test
   @WithAnonymousUser
   void getProfileStatus_GET() throws Exception {
-    // DockerService dockerService = mock(DockerService.class);
     ContainerInfo runningContainer = ContainerInfo.create(ProfileStatus.RUNNING);
     ContainerInfo offlineContainer = ContainerInfo.create(ProfileStatus.DOCKER_OFFLINE);
     // Mock DockerService to return a specific status

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -3,9 +3,7 @@ package org.molgenis.armadillo.controller;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.molgenis.armadillo.security.RunAs.runAsSystem;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -152,6 +150,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
   @Test
   @WithAnonymousUser
   void getProfileStatus_GET() throws Exception {
+    // DockerService dockerService = mock(DockerService.class);
     ContainerInfo runningContainer = ContainerInfo.create(ProfileStatus.RUNNING);
     ContainerInfo offlineContainer = ContainerInfo.create(ProfileStatus.DOCKER_OFFLINE);
     // Mock DockerService to return a specific status

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -21,10 +21,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.molgenis.armadillo.TestSecurityConfig;
-import org.molgenis.armadillo.metadata.ProfileConfig;
-import org.molgenis.armadillo.metadata.ProfileService;
-import org.molgenis.armadillo.metadata.ProfilesLoader;
-import org.molgenis.armadillo.metadata.ProfilesMetadata;
+import org.molgenis.armadillo.metadata.*;
+import org.molgenis.armadillo.profile.ContainerInfo;
 import org.molgenis.armadillo.profile.DockerService;
 import org.molgenis.armadillo.storage.ArmadilloStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -148,5 +146,49 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
     var expected = createExampleSettings();
     expected.getProfiles().remove("omics");
     verify(profilesLoader).save(expected);
+  }
+
+  @Test
+  @WithMockUser(roles = "SU")
+  void getProfileStatus_GET() throws Exception {
+    ContainerInfo runningContainer = ContainerInfo.create(ProfileStatus.RUNNING);
+    ContainerInfo offlineContainer = ContainerInfo.create(ProfileStatus.DOCKER_OFFLINE);
+    // Mock DockerService to return a specific status
+    when(dockerService.getProfileStatus("default"))
+        .thenReturn(runningContainer); // Example of a running container
+    when(dockerService.getProfileStatus("omics"))
+        .thenReturn(offlineContainer); // Example of a stopped container
+    String[] config = {
+      "DEBUG=FALSE",
+      "PATH=/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "JAVA_HOME=/opt/java/openjdk",
+      "LANG=C.UTF-8",
+      "LANGUAGE=C.UTF-8",
+      "LC_ALL=C.UTF-8",
+      "JAVA_VERSION=jdk-21.0.5+11",
+      "ROCK_VERSION=2.1.1",
+      "DSBASE_VERSION=6.3.1",
+      "DSMEDIATION_VERSION=0.0.3",
+      "DSEXPOSOME_VERSION=2.0.9",
+      "DSTIDYVERSE_VERSION=v1.0.1",
+      "DSOMICS_VERSION=v1.0.18-2",
+      "DSMTL_VERSION=0.9.9",
+      "DSSURVIVAL_VERSION=v2.1.3"
+    };
+
+    when(dockerService.getProfileEnvironmentConfig("default")).thenReturn(config);
+
+    // Perform the GET request to fetch the profile status
+    mockMvc
+        .perform(get("/ds-profiles/status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    "["
+                        + "{\"name\":\"default\",\"status\":\"RUNNING\",\"config\":\"[JAVA_VERSION=jdk-21.0.5+11, ROCK_VERSION=2.1.1, DSBASE_VERSION=6.3.1, DSMEDIATION_VERSION=0.0.3, DSEXPOSOME_VERSION=2.0.9, DSTIDYVERSE_VERSION=v1.0.1, DSOMICS_VERSION=v1.0.18-2, DSMTL_VERSION=0.9.9, DSSURVIVAL_VERSION=v2.1.3]\",\"image\":\"datashield/armadillo-rserver:6.2.0\"},"
+                        + "{\"name\":\"omics\",\"status\":\"DOCKER_OFFLINE\",\"config\":\"[]\",\"image\":\"datashield/armadillo-rserver-omics\"}"
+                        + "]"));
   }
 }


### PR DESCRIPTION
how to test:
- start and call endpoint `/ds-profiles/status`
(probably not very informative on preview because dockermanagement isn't enabled there (?)) 

Example of output:
```
[
  {
    "image": "datashield/rock-lemon-donkey:latest",
    "name": "default",
    "config": "[JAVA_VERSION=jdk-21.0.5+11, ROCK_VERSION=2.1.1, DSBASE_VERSION=6.3.1, DSMEDIATION_VERSION=0.0.3, DSEXPOSOME_VERSION=2.0.9, DSTIDYVERSE_VERSION=v1.0.1, DSOMICS_VERSION=v1.0.18-2, DSMTL_VERSION=0.9.9, DSSURVIVAL_VERSION=v2.1.3]",
    "status": "RUNNING"
  },
  {
    "image": "datashield/rock-lemon-donkey:latest",
    "name": "donkey",
    "status": "NOT_FOUND"
  },
  {
    "image": "datashield/rock-dolomite-xenon:2.0.0",
    "name": "xenon",
    "config": "[JAVA_VERSION=jdk-21.0.2+13, ROCK_VERSION=2.0.1, DSBASE_VERSION=6.3.0, DSMEDIATION_VERSION=0.0.3, DSEXPOSOME_VERSION=2.0.9, DSOMICS_VERSION=v1.0.18-2, DSMTL_VERSION=0.9.9, DSURVIVAL_VERSION=v2.1.3]",
    "status": "RUNNING"
  },
  {
    "image": "datashield/armadillo-rserver_caravan-xenon:latest",
    "name": "rserve-xenon",
    "config": "[R_VERSION=4.1.3, ARROW_VERSION=8.0.0, MOLGENISRSERVER_VERSION=0.1.2]",
    "status": "RUNNING"
  }
]
```

todo:
- [x] check if output is what we want, if not fix that
- [x] add tests
- [x] check if safe enough for endpoint for anonymous user
