### PR TITLE
BREAKING CHANGE: Migrate to armadillo 5 running Java 21

### DIFF
--- a/docs/pages/install_management/armadillo_install.md
+++ b/docs/pages/install_management/armadillo_install.md
@@ -19,7 +19,7 @@ In case of using dsOmics this setup can be rather bigger. Please [contact](../co
 
 ## Software requirements
 
-* Java 19 JRE or JDK
+* Java 21 JRE or JDK
 * Docker
 
 In addition to these, there are other optional components you may wish to install, such as setting up nginx as a reverse proxy.

--- a/docs/pages/install_management/armadillo_migrate_3_to_4.md
+++ b/docs/pages/install_management/armadillo_migrate_3_to_4.md
@@ -1,304 +1,302 @@
-# Migrate Armadillo 2 to Armadillo 3
+# Migrate Armadillo 3 to Armadillo 4
 
-Migrating from Armadillo 2 to Armadillo 3 can be done in two variants, a full migration including [projects, users and data](#migrate-projects-users-and-data) or [just projects and their users](#migrate-projects-and-their-users).
-Both options require Python (version 3.8) and additional python libraries, described in [Getting started](#getting-started).
-
-## Getting started
-
-To start the migration, python 3.8 is advised together with a number of utilitarian python libraries. Other python
-versions might work, but performance has only been tested with python 3.8.
-
-### Install with Python virtual environment
-
-For more info see [python virtual environment](https://docs.python.org/3/library/venv.html).
-
-The following code does not require superuser rights. The code does assume you are already in the [scripts/upgrade](https://github.com/molgenis/molgenis-service-armadillo/tree/master/scripts/upgrade) directory.
-
-```bash
-python3 -m venv venv
-source ./venv/bin/activate
-pip install -r requirements.txt
-```
-
-??? tip
-    If the installation of one (or more libraries) fails, try to install the libraries one by one.
-
-## Migrate Projects, users and data
-
-### 1. Check if there's enough space left on the server
-
-```bash
-df -h
-```
-
-Compare to:
-
-```bash
-du -h /var/lib/minio
-```
-
-??? warning
-    Available space should be at least twice the size of the MinIO folder.
-
-### 2. Backup Armadillo 2 settings
-
-```bash
-mkdir armadillo2-backup 
-rsync -avr /usr/share/armadillo armadillo2-backup 
-cp /etc/armadillo/application.yml armadillo2-backup/application-armadillo2.yml 
-```
-
-???+ note
-    Change `/usr/share` to the path matching your local config.
-
-### 3. Install helper software
-
-FIXME: Skip these steps as you have already done installing the python code in a virtual env.
-
-Login to your server as root, using ssh.
-
-```bash
-apt update
-
-#apt install pip
-#pip install minio
-#pip install fusionauth-client
-#pip install simple_term_menu
-```
-
-If you get a purple message asking to update, accept and install everything.
-
-Restart of server is recommended after this.
+Upgrade to Armadillo 4 (rock only)
 
 ??? note
-    The commands in this manual are for Ubuntu, on other linux systems, the `apt` command needs to be replaced with the correct one.
+    We assume Ubuntu with systemd is used.
 
-### 4. Stop all docker images for Armadillo 2
+The upgrade from Armadillo v3.4 to 4.x is breaking as the profiles must be Rock profiles.
 
-List all docker images
+Additionally, when working with an armadillo 4 instance, researchers should update `DSMolgenisArmadillo` to version 2.0.5 (this version is compatible with armadillo 3 as well).
 
-```bash
-docker ps -a
-```
+## Get latest version
 
-Stop and remove all Armadillo 2 related images (except for MinIO), e.g.
+For the latest 4.x release check https://github.com/molgenis/molgenis-service-armadillo/releases/latest. This will redirect to a v4.x.y page.
 
-```bash
-docker rm armadillo_auth_1 armadillo_console_1 armadillo_rserver-default_1 armadillo_rserver-mediation_1 armadillo_rserver-exposome_1 armadillo_rserver-omics_1 armadillo_armadillo_1 -f 
-```
+Make a note of the version as you will use this below.
 
-Check with `docker ps -a` if there are still containers running, if so remove these (**except for the MinIO**) in the same way as the others.
+## 1. Check your profile types
 
-???+ warning
-    Make sure you do **not** remove the docker instance of MinIO before you migrated the data!
+Check if the new profiles are compatible with your needs, these profile names can be edited later on in the manual:
 
-### 5. Install armadillo
+    - datashield/rock-base:latest
+    - datashield/rock-dolomite-xenon:latest
 
-```bash
-apt update
-apt install openjdk-19-jre-headless
-apt install docker.io
-```
+See also DataSHIELD profiles
 
-The docker.io step might fail because containerd already exists, if that's the case, remove containerd and try again:
+## 2. Check server space
+
+Make sure enough disk space is available for the Rock only images.
+
+### 2.1 Check disk space
 
 ```bash
-apt remove containerd.io
-apt install docker.io
+# Check disk space
+df -H
 ```
 
-Get armadillo:
+If you have 15 GB or more available, you can continue. If you have less available, check `docker image list` to see if you can cleanup some docker images (you only need the latest `datashield/armadillo-rserver` and `datashield/armadillo-rserver_caravan-xenon` for armadillo 3).
+
+### 2.2 Check docker images
+
+First stop all profiles through the Armadillo UI.
+
+Now that the profiles are not running you can delete the old versions of their docker images.
+
+The command are indicative so change as needed.
 
 ```bash
-wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/install/armadillo-setup.sh 
-bash armadillo-setup.sh \
-    --admin-user admin \
-    --admin-password xxxxx 
-    --domain my.server.com \
-    --oidc \
-    --oidc_url https://lifecycle-auth.molgenis.org \
-    --oidc_clientid clientid \
-    --oidc_clientsecret secret \
-    --cleanup \
+# should return empty list (i.e. default, xenon, rock)
+docker container list
+
+# remove containers not needed
+docker container stop <id>
+docker container rm <id>
+
+# remove unneeded images/profiles (ie. caravan, ...)
+docker image list
+docker image rm <id>
 ```
 
-Don't forget to set a proper admin password (use a generator), domain, clientid and clientsecret. The client id and
-secret can be found on the lifecycle auth server in the configuration for your server. If you don't have permissions to
-receive this, you can ask the support team to get it for you.
+If possible download the new images from shell using `docker pull` beforehand (for minimum downtime):
 
-Open armadillo in the browser and try to login using basicauth to check if the server is running properly. If it is not
-running at all, try:
+```bash
+docker pull datashield/rock-base:latest
+docker pull datashield/rock-dolomite-xenon:latest
+```
+
+Check disk space again.
+
+```bash
+# Check disk space
+df -H
+```
+
+## 3. Download required files
+
+Make a note of the version number ie. `v4.1.3` as you need to download some files from the terminal using the update script.
+
+### 3.1 Update script
+
+You need to be root user.
+
+```bash
+cd /root
+# Change the versions number v4.x.y
+mkdir v4.x.y
+cd v4.x.y
+
+# Check directory location
+pwd
+```
+
+```bash
+# Change the version number v4.x.y then run command
+wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/v4.x.y/scripts/install/armadillo-check-update.sh
+```
+
+Make the script runnable
+```bash
+chmod u+x armadillo-check-update.sh
+```
+
+### 3.2 Run update script
+
+You can run the following script to download the new Armadillo version.
+
+??? note
+    The output could help us to help you fix problems.
+
+```bash
+# Change the version number v4.x.y
+./armadillo-check-update.sh 4.x.y
+```
+
+Once the script has completed, you can verify that the Armadillo JAR file has been downloaded by checking the directory:
+
+```bash
+# See all jar files on your system
+ls -ltr /usr/share/armadillo/application/
+```
+
+## 4. Config the new version
+
+### 4.1 application.yml
+
+To compare the latest template to your own configuration, see the troubleshooting section below. The safest way to update armadillo is by fetching the template and filling it in with your configuration using the information in the troubleshooting section. You can try the following first:
+
+Edit the application.yml:
+
+```bash
+nano /etc/armadillo/application.yml
+```
+
+Below the line `docker-management-enabled: true`, ensure to insert the line `docker-run-in-container: false`. Typically, you'll find these configurations at the beginning of the file.
+
+## 4.2 Make backup of system config
+
+```bash
+# Still in the correct directory? (`/root/v4.x.y`)
+pwd
+```
+
+We make a backup into the same `v4.x.y` directory but that is not strictly needed.
+
+```bash
+cp -r /usr/share/armadillo/data/system ./
+```
+
+should result in:
+
+```bash
+ls system/
+# access.json  profiles.json
+```
+
+## 5. Restart application using new version
+
+Armadillo has not yet been updated, follow the following steps to do so:
+
+### 5.1 Stop Armadillo
+
+```bash
+systemctl stop armadillo
+```
+
+### 5.2 Link new version
+
+```bash
+# List application files
+ls -l /usr/share/armadillo/application/
+
+# Remove the linked file
+rm /usr/share/armadillo/application/armadillo.jar
+
+# Attach new linked file and dont forget to change the version number v4.x.y
+ln -s /usr/share/armadillo/application/armadillo-4.x.y.jar /usr/share/armadillo/application/armadillo.jar
+
+# Check result
+ls -l /usr/share/armadillo/application/
+```
+
+### 5.3 Restart Armadillo
 
 ```bash
 systemctl start armadillo
+systemctl status armadillo
 ```
 
-### 6. Export data from Armadillo 2 into armadillo 3
+## 6. Log on to the UI
 
-Look up the user/password in the application.yml of the old armadillo. They are called MinIO access key and minio secret key.
+Go to your armadillo website. Is the version in the left top corner updated? This means the update was successful.
+
+## 7. Update profiles
+
+Login into the website and go to the profiles tab. Here two profiles should be listed: `default` and `xenon`.
+Any other profiles can be removed.
+
+1. Edit the default profile.
+2. Change the "image" to `datashield/rock-base:latest` and save.
+3. Start the default profile.
+4. Edit the "xenon" profile.
+5. Change the "image" to `datashield/rock-dolomite-xenon:latest` and save.
+6. Start the xenon profile.
+
+Everything should now be working correctly. You can try and login to your server via the central analysis server, using
+the `DSMolgenisArmadillo` (2.0.5 or up) package to test.
+
+## Troubleshooting
+
+### Logs
+
+Reviewing the log files can provide valuable insights into any issues or activities within the application. If you encounter any errors or unexpected behavior, examining the log files can often help diagnose the problem.
+
+Check log files location
 
 ```bash
-cat /root/armadillo2-backup/application-armadillo2.yml
+ls -l /var/log/armadillo/
 ```
 
-Do the following step in a separate screen. On ubuntu use:
+should look something like:
 
 ```bash
-screen
+-rw-r--r-- 1 root      root      111224 Jan 30 11:47 armadillo.log
+-rw-r--r-- 1 armadillo armadillo  68872 Jan 30 11:47 audit.log
+-rw-r--r-- 1 root      root        8428 Dec 19 11:57 error.log
 ```
 
-Navigate to the armadillo folder:
+If the `error.log` data/time is around current day/time you have to check this file.
 
 ```bash
-cd /usr/share/armadillo
+# See last 100 lines
+tail -n 100 /var/log/armadillo/error.log
 ```
 
-This step will copy Armadillo 2 data from minio into the folder matching of an Armadillo 3 data folder:
+Otherwise, you can look into `armadillo.log`:
 
 ```bash
-mkdir data
-wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/upgrade/migrate-minio.py
-python3 migrate-minio.py  --minio http://localhost:9000 --target /usr/share/armadillo/data  
+# See last 100 lines
+tail -n 100 /var/log/armadillo/armadillo.log
 ```
 
-This might take a couple of minutes. You can detach the screen using ++ctrl+a++ followed by ++d++ and reattach it using `screen -r`.
-
-### 7. Run Armadillo 3 using exported data
-
-Make sure to move the exported data into the new 'data' folder. Optionally you might need to fix user permissions, e.g.:
+or
 
 ```bash
-chown armadillo:armadillo -R data 
+# Follow all files for changes (keep open to see activities)
+tail -f /var/log/armadillo/*
 ```
 
-Check if armadillo is running by going to the URL of your server in the browser, login and navigate to the projects tab.
+### Compare application.yml
 
-### 8. Optionally, acquire a permission set from MOLGENIS team
-
-If you previously ran a central authorisation server with MOLGENIS team, they can provide you with procedure to load pre-existing permissions. They will use:
+Although we try to be very complete in this manual, if you run into issues, it might be because a setting was changed
+in the application.yml. You can check if application settings has any new entries by first downloading the application template (for reference).
 
 ```bash
-wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/master/scripts/upgrade/migrate-auth.py
-python3 migrate-auth.py  --fusion-auth https://lifecycle-auth.molgenis.org --armadillo https://thearmadillourl.net
+# Change the version number v4.x.y
+wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/v4.x.y/application.template.yml
 ```
 
-Now check if all users and data are properly migrated.
-
-??? note
-    If the script fails with a timeout, try pinging the armadillo url and lifecycle auth url to see if they're reachable from the server. In case they are not, you could choose to export the users using the `export-users.py` script locally and then manually enter them into the system.
-
-### 9. Cleanup ngnix config
-
-Change `/etc/nginx/sites-available/armadillo.conf` to:
+To see the difference run:
 
 ```bash
-server {
-  listen 80;
-  server_name urlofyourserver.org
-  include /etc/nginx/global.d/*.conf;
-  location / {
-  proxy_pass http://localhost:8080;
-  client_max_body_size 0;
-  proxy_read_timeout 600s;
-  proxy_redirect http://localhost:8080/ $scheme://$host/;
-  proxy_set_header Host $host;
-  proxy_http_version 1.1;
-  }
-}
+diff --side-by-side /etc/armadillo/application.yml application.template.yml
 ```
 
-??? note
-    Note that the `https://` is missing in the server_name part.
-??? note
-    If port 443 and the SSL certificates are in the old config, you mind have to keep that part, so you should not comment that out. Keep the listen and certificate lines, comment out the rest and paste the config above below the existing config.
+Your output should look like output below.
 
-Remove the console, auth and storage file from: `/etc/nginx/sites-enabled/` and `/etc/nginx/sites-available/`.
+- Left side column is your settings.
+- Right side column is our expected settings.
+- In the middle some symbols may occur:
+  - the `&lt;` means only your settings
+  - the `&gt;` means we have a setting (probably added or options)
+  - the `|` means both have different values which happens with OICD/oauth settings for sure.
 
 ```bash
-systemctl restart nginx
+armadillo:                            armadillo:
+  # set this false if you DON'T want Armadillo to create/edit      # set this false if you DON'T want Armadillo to create/edit
+  docker-management-enabled: true                  docker-management-enabled: true
+....
+audit:                                  <
+  log:                                  <
+    path: /var/log/armadillo/audit.log  <
+                                        <
+....
+
+storage:                                         storage:
+  ## to change location of the data storage        ## to change location of the data storage
+  root-dir: /usr/share/armadillo/data           |  root-dir: data
 ```
 
-### 10. Fix application.yml
-
-Make sure the following is added:
+Making changes may be a little tricky. You can backup
 
 ```bash
-server:
-forward-headers-strategy: framework
+cp /etc/armadillo/application.yml ./
+# list files
+ls .
 ```
 
-### 11. Fix URLs in the lifecycle FusionAuth
-
-Add the following to the config of your server: `https://yourserver.com/login/oauth2/code/molgenis`
-
-### 12. Set up profiles
-
-Login to armadillo in the browser. Navigate to the "Profiles" tab. Add a new profile with the following properties:
-
-Name: `xenon`  
-Image: `datashield/armadillo-rserver_caravan-xenon:latest`  
-Package whitelist: `dsBase`, `resourcer`, `dsMediation`, `dsMTLBase`, `dsSurvival`, `dsExposome`
-
-Assign a random 9-number seed and create and start the container.
-
-### 13. Remove old MinIO data
-
-First remove the MinIO docker container. First check the name of the container using `docker ps -a`, then:
+then edit
 
 ```bash
-docker rm containername -f
-```
-
-After that remove the data:
-
-```bash
-rm -Rf /var/lib/minio/
-```
-
-???+ warning
-    Be sure you have migrated your data successfully or created a backup prior to deleting your minio data folder!
-
-## Migrate Projects and their users
-
-Migration of just the projects and their users (with their corresponding rights) can be done by using [export-users.py](https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/upgrade/export-users.py) and [import-users.py](https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/upgrade/import-users.py).
-
-???+ warning
-    This options does not migrate the data!
-
-### 1. Export Projects and users from Armadillo 2
-
-To export users from an Armadillo 2 server, one must use the [export-users.py](https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/upgrade/export-users.py) script. `export-users.py` can be used by using the following arguments:
-
-- -f / --fusion-auth **(required)**: The full URL (including http) of the Armadillo 2 server of which you wish to export the Projects and their users from. **Please note that `export-users.py` will prompt to supply the API key for this server once all arguments are valid!**
-- -o / --output **(required)**: The output directory in which (unzipped) TSVs will be placed of all projects and their users, with the project name being the TSV name. `export-users.py` will create a new folder in the supplied output folder named: `YYYY-MM-DD`, where `YYYY` is the current year, `MM` is the current month and `DD` is the current day.
-
-**Again, note that `export-users.py` will prompt to supply the API key for the `-f / --fusion-auth` server once all arguments are valid!**
-
-Empty projects (without users) will also be exported as an empty TSV (containing only the header). This is a feature that `import-users.py`, the next step, is able to function with.
-
-Also note that some projects might change in name, as Armadillo 3 is stricter with naming projects.
-
-Example:
-
-```bash
-pipenv shell
-python3 export-users.py -f https://armadillo2-server.org -o ./armadillo_2_exports
-```
-
-### 2. Import Projects and users TSVs into Armadillo 3
-
-To import users into an Armadillo 3 server, one must use the [import-users.py](https://github.com/molgenis/molgenis-service-armadillo/blob/master/scripts/upgrade/import-users.py) script. `import-users` can be used by using the following arguments:
-
-- -s / --server **(required)**: The full URL (including http) of the Armadillo 3 server of which you wish to import the Projects and their users TSVs in [step 1](#1-export-projects-and-users-from-armadillo-2). **Please note that `import-users.py` will prompt to supply the API key for this server once all arguments are valid!**
-- -d / --user-data **(required)**: The directory, including the folder named after the year-month-day combination, where the export TSVs from [step 1](#1-export-projects-and-users-from-armadillo-2) are stored.
-
-**Again, note that `import-users.py` will prompt to supply the API key for the `-s / --server` server once all arguments are valid!**
-
-Empty TSVs from [step 1](#1-export-projects-and-users-from-armadillo-2) will be imported as empty projects with no users.
-
-Example:
-
-```bash
-pipenv shell
-python3 import-users.py -s https://armadillo3-server.org -d ./armadillo_2_exports/2023-11-09
+nano /etc/armadillo/application.yml
 ```

--- a/docs/pages/install_management/armadillo_migrate_4_to_5.md
+++ b/docs/pages/install_management/armadillo_migrate_4_to_5.md
@@ -1,0 +1,89 @@
+# Migrate Armadillo 4 to Armadillo 5
+
+MOLGENIS Armadillo v5.x.y depends on Java 21, support for all older versions of Java are dropped, so if your Armadillo instance is not
+running on Java 21 yet, you'll have to update. To do so:
+
+## 1. Get the update script
+
+```bash
+cd /root
+# Change the versions number v5.x.y
+mkdir v5.x.y
+cd v5.x.y
+```
+
+```bash
+# Change the version number v5.x.y then run command
+wget https://raw.githubusercontent.com/molgenis/molgenis-service-armadillo/v5.x.y/scripts/install/armadillo-check-update.sh
+```
+
+Make the script runnable
+```bash
+chmod u+x armadillo-check-update.sh
+```
+
+## 2. Run the update script 
+
+```bash
+# Change the version number v5.x.y
+./armadillo-check-update.sh 5.x.y
+```
+
+Once the script has completed, you can verify that the Armadillo JAR file has been downloaded by checking the directory:
+
+```bash
+# See all jar files on your system
+ls -ltr /usr/share/armadillo/application/
+```
+
+## 3. Make backup of system config
+```bash
+# Still in the correct directory? (`/root/v5.x.y`)
+pwd
+```
+
+We make a backup into the same `v5x.y` directory but that is not strictly needed.
+
+```bash
+cp -r /usr/share/armadillo/data/system ./
+```
+
+```bash
+ls system/
+# access.json  profiles.json
+```
+
+## 4. Stop Armadillo
+``` bash
+systemctl stop armadillo
+```
+
+## 5. Update Java
+``` bash
+apt update
+apt install openjdk-21-jre-headless
+```
+
+## 6. Link new version
+
+```bash
+# List application files
+ls -l /usr/share/armadillo/application/
+
+# Remove the linked file
+rm /usr/share/armadillo/application/armadillo.jar
+
+# Attach new linked file and dont forget to change the version number v5.x.y
+ln -s /usr/share/armadillo/application/armadillo-5.x.y.jar /usr/share/armadillo/application/armadillo.jar
+
+# Check result
+ls -l /usr/share/armadillo/application/
+```
+
+
+## 7 Restart Armadillo
+
+```bash
+systemctl start armadillo
+systemctl status armadillo
+```

--- a/docs/pages/install_management/index.md
+++ b/docs/pages/install_management/index.md
@@ -4,5 +4,6 @@
     - [Armadillo Installation](../install_management/armadillo_install.md)
     - [Armadillo Management](../install_management/armadillo_management.md)
     - [Armadillo minor release update](../install_management/armadillo_minor_release_update.md)
-    - [Migrate Armadillo 2 to Armadillo 3](../install_management/armadillo_migrate_2_to_3.md)
-    - [Migrate Armadillo 3 to Armadillo 4](../install_management/armadillo_migrate_3_to_4.md)
+    - [Migrate Armadillo 2 to Armadillo 3](../install_management/armadillo_migrate_2_to_3)
+    - [Migrate Armadillo 3 to Armadillo 4](../install_management/armadillo_migrate_3_to_4)
+    - [Migrate Armadillo 4 to Armadillo 5](../install_management/armadillo_migrate_4_to_5)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - "Armadillo Minor Release Update": pages/install_management/armadillo_minor_release_update.md
       - "Migrate Armadillo 2 to 3": pages/install_management/armadillo_migrate_2_to_3.md
       - "Migrate Armadillo 3 to 4": pages/install_management/armadillo_migrate_3_to_4.md
+      - "Migrate Armadillo 4 to 5": pages/install_management/armadillo_migrate_4_to_5.md
   - "Developer guides": pages/dev_guides.md
   - "License": pages/license.md
   - "FAQ": pages/faq.md

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -18,9 +18,9 @@
                 You are logged in, but you don't have permission to access the
                 Armadillo user interface.
                 <div>
-                  Don't worry, you can still do your research using the R client.
-                  If you believe you should have permission to access this user
-                  interface, please contact an administrator.
+                  Don't worry, you can still do your research using the R
+                  client. If you believe you should have permission to access
+                  this user interface, please contact an administrator.
                 </div>
               </Alert>
               {{ errorMessage }}
@@ -35,21 +35,16 @@
         </div>
       </div>
     </div>
-    <footer class="text-primary text-center py-3 border-top">
-      <div class="container">
-        <p class="mb-0"><small class="text-muted">Please cite <a href="https://doi.org/10.1093/bioinformatics/btae726">Cadman et al. (2024)</a> when publishing research conducted using Armadillo.</small></p>
-        <p class="mb-0"><small class="text-muted">This platform was created using <a href="https://molgenis.org/">MOLGENIS.org</a><a href="https://github.com/molgenis/molgenis-service-armadillo"> (Github)</a>.</small></p>
-      </div>
-    </footer>
+    <Footer />
   </div>
 </template>
-
 
 <script lang="ts">
 import Navbar from "@/components/Navbar.vue";
 import Tabs from "@/components/Tabs.vue";
 import Login from "@/views/Login.vue";
 import Alert from "@/components/Alert.vue";
+import Footer from "./components/Footer.vue";
 import { defineComponent, onMounted, ref, Ref } from "vue";
 import {
   getPrincipal,
@@ -73,6 +68,7 @@ export default defineComponent({
     Tabs,
     Login,
     Alert,
+    Footer,
   },
   setup() {
     const isAuthenticated: Ref<boolean> = ref(false);

--- a/ui/src/components/Footer.vue
+++ b/ui/src/components/Footer.vue
@@ -1,0 +1,40 @@
+<template>
+  <footer class="text-primary text-center py-3 border-top">
+    <div class="container">
+      <p class="mb-0">
+        <small class="text-muted"
+          >Please cite
+          <a href="https://doi.org/10.1093/bioinformatics/btae726">
+            Cadman et al. (2024)
+          </a>
+          when publishing research conducted using Armadillo
+          <a
+            href="https://www.ravelry.com/patterns/library/roll-up-armadillo"
+            target="_blank"
+          >
+            <i class="bi bi-egg"></i>
+          </a>
+          .
+        </small>
+      </p>
+      <p class="mb-0">
+        <small class="text-muted">
+          This platform was created using
+          <a href="https://molgenis.org/">MOLGENIS.org</a>
+          <a href="https://github.com/molgenis/molgenis-service-armadillo">
+            (Github)
+          </a>
+          .
+        </small>
+      </p>
+    </div>
+  </footer>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "Footer",
+});
+</script>


### PR DESCRIPTION
- [ ] Check if all migration pages now link to the right migrations ( you can ignore the rest of the content in the 2-3 and 3-4 docs)
- [ ] Check if the migration for armadillo 5 makes sense