### PR TITLE
feat: all docker images endpoint

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
@@ -54,7 +54,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String GET_USER = "GET_USER";
   public static final String LIST_ACCESS_DATA = "LIST_ACCESS_DATA";
   public static final String LIST_PROJECTS = "LIST_PROJECTS";
-
+  public static final String GET_DOCKER_IMAGES = "GET_DOCKER_IMAGES";
   public static final String LIST_FILES = "LIST_FILES";
   public static final String FILE_DETAILS = "FILE_DETAILS";
   public static final String DOWNLOAD_FILE = "DOWNLOAD_FILE";

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/InsightController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/InsightController.java
@@ -6,7 +6,6 @@ import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 
-import com.github.dockerjava.api.model.Image;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,6 +23,7 @@ import org.molgenis.armadillo.audit.AuditEventPublisher;
 import org.molgenis.armadillo.metadata.FileDetails;
 import org.molgenis.armadillo.metadata.FileInfo;
 import org.molgenis.armadillo.metadata.InsightService;
+import org.molgenis.armadillo.model.DockerImageInfo;
 import org.molgenis.armadillo.profile.DockerService;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -127,7 +127,7 @@ public class InsightController {
 
   @GetMapping(path = "docker/all-images", produces = APPLICATION_JSON_VALUE)
   @ResponseStatus(OK)
-  public List<Image> getDockerImages(Principal principal) {
+  public List<DockerImageInfo> getDockerImages(Principal principal) {
     assert dockerService != null;
     return auditor.audit(dockerService::getDockerImages, principal, GET_DOCKER_IMAGES);
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/model/DockerImageInfo.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/model/DockerImageInfo.java
@@ -1,0 +1,44 @@
+package org.molgenis.armadillo.model;
+
+import static org.molgenis.armadillo.storage.LocalStorageService.getFileSizeInUnit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.dockerjava.api.model.Image;
+import com.google.auto.value.AutoValue;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.*;
+
+@AutoValue
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class DockerImageInfo {
+
+  @NotEmpty
+  public abstract Image image();
+
+  @JsonProperty("created")
+  public Date getCreated() {
+    return new Date(image().getCreated() * 1000);
+  }
+
+  @JsonProperty("size")
+  public String getSize() {
+    return getFileSizeInUnit(image().getSize());
+  }
+
+  @JsonProperty("imageId")
+  public String getImageId() {
+    return image().getId();
+  }
+
+  @JsonProperty("repoTags")
+  public String[] getRepoTags() {
+    return image().getRepoTags();
+  }
+
+  @JsonCreator
+  public static DockerImageInfo create(Image image) {
+    return new AutoValue_DockerImageInfo(image);
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -288,6 +288,10 @@ public class DockerService {
     return emptyList();
   }
 
+  public List<Image> getDockerImages() {
+    return dockerClient.listImagesCmd().withShowAll(TRUE).exec();
+  }
+
   void removeImageIfUnused(String imageId) {
     if (imageId == null) {
       LOG.info("No image ID provided; skipping image removal");

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -23,6 +23,7 @@ import org.molgenis.armadillo.exceptions.*;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
 import org.molgenis.armadillo.metadata.ProfileStatus;
+import org.molgenis.armadillo.model.DockerImageInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -288,8 +289,10 @@ public class DockerService {
     return emptyList();
   }
 
-  public List<Image> getDockerImages() {
-    return dockerClient.listImagesCmd().withShowAll(TRUE).exec();
+  public List<DockerImageInfo> getDockerImages() {
+    return dockerClient.listImagesCmd().withShowAll(TRUE).exec().stream()
+        .map(DockerImageInfo::create)
+        .toList();
   }
 
   void removeImageIfUnused(String imageId) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/LocalStorageService.java
@@ -174,7 +174,7 @@ public class LocalStorageService implements StorageService {
     }
   }
 
-  String getFileSizeInUnit(long fileSize) {
+  public static String getFileSizeInUnit(long fileSize) {
     int sizeOfUnit = 1024;
     String[] units = new String[] {"bytes", "KB", "MB", "GB"};
     for (String unit : units) {

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/InsightControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/InsightControllerTest.java
@@ -46,7 +46,7 @@ public class InsightControllerTest {
   @MockitoBean DockerService dockerService;
 
   @Test
-  public void testFilesList() throws Exception {
+  void testFilesList() throws Exception {
     mockMvc
         .perform(get("/insight/files"))
         .andExpect(status().isOk())
@@ -54,7 +54,7 @@ public class InsightControllerTest {
   }
 
   @Test
-  public void testFilesDetail() throws Exception {
+  void testFilesDetail() throws Exception {
     mockMvc
         .perform(get("/insight/files/XyZ"))
         .andExpect(status().isOk())
@@ -65,7 +65,7 @@ public class InsightControllerTest {
   }
 
   @Test
-  public void testGetDockerImages() throws Exception {
+  void testGetDockerImages() throws Exception {
     // Arrange
     Image mockImage = mock(Image.class);
     when(mockImage.getId()).thenReturn("sha256:1234");

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -360,6 +360,7 @@ class DockerServiceTest {
     assertEquals(expectedId, result.getImageId());
     assertEquals(expectedTags[0], result.getRepoTags()[0]);
     assertEquals("11 MB", result.getSize());
-    assertEquals("Mon Jul 28 16:13:49 CEST 2025", result.getCreated().toString());
+    // difference in string value between mac and linux, but starts the same way
+    assertTrue(result.getCreated().toString().startsWith("Mon Jul 28 "));
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -17,6 +17,7 @@ import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.command.RemoveImageCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.Image;
 import jakarta.ws.rs.ProcessingException;
 import java.net.SocketException;
 import java.util.List;
@@ -33,6 +34,7 @@ import org.molgenis.armadillo.exceptions.MissingImageException;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
 import org.molgenis.armadillo.metadata.ProfileStatus;
+import org.molgenis.armadillo.model.DockerImageInfo;
 
 @ExtendWith(MockitoExtension.class)
 class DockerServiceTest {
@@ -337,5 +339,27 @@ class DockerServiceTest {
     verify(spyService).removeProfile(profileName);
     verify(profileService).getByName(profileName);
     verify(spyService).removeImageIfUnused(imageId);
+  }
+
+  @Test
+  void testCreateFromImage() {
+    // Given
+    String expectedId = "sha256:abcd1234";
+    String[] expectedTags = {"my-image:latest"};
+    Image mockImage = mock(Image.class);
+    when(mockImage.getId()).thenReturn(expectedId);
+    when(mockImage.getRepoTags()).thenReturn(expectedTags);
+    when(mockImage.getSize()).thenReturn(12345678L);
+    when(mockImage.getCreated()).thenReturn(1753712029L);
+
+    // When
+    DockerImageInfo result = DockerImageInfo.create(mockImage);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(expectedId, result.getImageId());
+    assertEquals(expectedTags[0], result.getRepoTags()[0]);
+    assertEquals("11 MB", result.getSize());
+    assertEquals("Mon Jul 28 16:13:49 CEST 2025", result.getCreated().toString());
   }
 }


### PR DESCRIPTION
how to test:
- Install armadillo locally
- Make sure docker is running with some images pulled in there
- Go to new swagger endpoint: http://localhost:8080/swagger-ui/index.html#/insight/getDockerImages
- Click on Execute and see all images there (including non-running)

todo:
- [x] updated docs in case of new feature (Swagger should be sufficient for API endpoint?)
- [x] added tests
