### PR TITLE
feat: remove docker image endpoint

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
@@ -54,7 +54,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String GET_USER = "GET_USER";
   public static final String LIST_ACCESS_DATA = "LIST_ACCESS_DATA";
   public static final String LIST_PROJECTS = "LIST_PROJECTS";
-
+  public static final String DELETE_DOCKER_IMAGE = "DELETE_DOCKER_IMAGE";
   public static final String LIST_FILES = "LIST_FILES";
   public static final String FILE_DETAILS = "FILE_DETAILS";
   public static final String DOWNLOAD_FILE = "DOWNLOAD_FILE";

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import org.molgenis.armadillo.command.Commands;
 import org.molgenis.armadillo.exceptions.FileProcessingException;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
+import org.molgenis.armadillo.profile.DockerService;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,12 +47,17 @@ public class DevelopmentController {
   private final Commands commands;
   private final AuditEventPublisher auditEventPublisher;
   private final ProfileService profiles;
+  private final DockerService dockerService;
 
   public DevelopmentController(
-      Commands commands, AuditEventPublisher auditEventPublisher, ProfileService profileService) {
+      Commands commands,
+      AuditEventPublisher auditEventPublisher,
+      ProfileService profileService,
+      @Nullable DockerService dockerService) {
     this.commands = requireNonNull(commands);
     this.auditEventPublisher = requireNonNull(auditEventPublisher);
     this.profiles = requireNonNull(profileService);
+    this.dockerService = dockerService;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -136,6 +143,24 @@ public class DevelopmentController {
         principal,
         UPSERT_PROFILE,
         Map.of(PROFILE, profileConfig));
+  }
+
+  @Operation(summary = "Delete a docker image", description = "Delete a docker image based on id")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "Object deleted successfully"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized")
+      })
+  @DeleteMapping(value = "delete-docker-image")
+  @ResponseStatus(NO_CONTENT)
+  @PreAuthorize("hasRole('ROLE_SU')")
+  public void deleteDockerImage(Principal principal, @RequestParam String imageId) {
+    assert dockerService != null;
+    auditEventPublisher.audit(
+        () -> dockerService.removeImageIfUnused(imageId),
+        principal,
+        DELETE_DOCKER_IMAGE,
+        Map.of(DELETE_DOCKER_IMAGE, imageId));
   }
 
   protected String getPackageNameFromFilename(String filename) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/exceptions/ImageRemoveFailedException.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/exceptions/ImageRemoveFailedException.java
@@ -1,0 +1,13 @@
+package org.molgenis.armadillo.exceptions;
+
+import static java.lang.String.format;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(INTERNAL_SERVER_ERROR)
+public class ImageRemoveFailedException extends RuntimeException {
+  public ImageRemoveFailedException(String image, String reason) {
+    super(format("Error while removing image '%s' because: %s", image, reason));
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -171,7 +171,11 @@ public class DockerService {
           safeProfileName,
           safePrevImageId,
           safeCurrImageId);
-      removeImageIfUnused(previousImageId);
+      try {
+        removeImageIfUnused(previousImageId);
+      } catch (ImageRemoveFailedException e) {
+        LOG.info(e.getMessage());
+      }
     } else {
       LOG.info(
           "Image ID for profile '{}' unchanged (still '{}')", safeProfileName, safeCurrImageId);
@@ -264,7 +268,11 @@ public class DockerService {
   public void deleteProfile(String profileName) {
     removeProfile(profileName);
     String imageId = profileService.getByName(profileName).getLastImageId();
-    removeImageIfUnused(imageId);
+    try {
+      removeImageIfUnused(imageId);
+    } catch (ImageRemoveFailedException e) {
+      LOG.info(e.getMessage());
+    }
   }
 
   private void removeContainer(String containerName) {
@@ -288,7 +296,7 @@ public class DockerService {
     return emptyList();
   }
 
-  void removeImageIfUnused(String imageId) {
+  public void removeImageIfUnused(String imageId) {
     if (imageId == null) {
       LOG.info("No image ID provided; skipping image removal");
       return;
@@ -298,18 +306,18 @@ public class DockerService {
 
     try {
       boolean isInUse =
-          dockerClient.listContainersCmd().withShowAll(true).exec().stream()
+          dockerClient.listContainersCmd().exec().stream()
               .anyMatch(container -> Objects.equals(container.getImageId(), imageId));
 
       if (isInUse) {
         LOG.info("Image ID '{}' is still in use — skipping removal", safeImageId);
-        return;
+        throw new ImageRemoveFailedException(
+            safeImageId, "Image ID is still in use — skipping removal");
       }
-
       dockerClient.removeImageCmd(imageId).withForce(true).exec();
       LOG.info("Removed image ID '{}' from local Docker cache", safeImageId);
     } catch (NotFoundException e) {
-      LOG.info("Image ID '{}' not found locally; skipping removal", safeImageId);
+      throw new ImageRemoveFailedException(safeImageId, "Image ID not found — skipping removal");
     }
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/DevelopmentControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/DevelopmentControllerTest.java
@@ -3,7 +3,7 @@ package org.molgenis.armadillo.controller;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -125,5 +125,22 @@ class DevelopmentControllerTest extends ArmadilloControllerTestBase {
         new DevelopmentController(commands, auditEventPublisher, profileService, dockerService);
     String pkgName = controller.getPackageNameFromFilename(filename);
     assertEquals("hello_world", pkgName);
+  }
+
+  @Test
+  @WithMockUser(roles = "SU")
+  void testDeleteDockerImage() throws Exception {
+    String imageId = "some-image-id";
+
+    // We mock the dockerService.removeImageIfUnused to do nothing (void method)
+    // You can verify later if needed.
+    doNothing().when(dockerService).removeImageIfUnused(imageId);
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("/delete-docker-image").param("imageId", imageId))
+        .andExpect(status().isNoContent());
+
+    // Verify that dockerService.removeImageIfUnused was called with the correct imageId
+    verify(dockerService).removeImageIfUnused(imageId);
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/DevelopmentControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/DevelopmentControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.github.dockerjava.api.DockerClient;
 import java.security.Principal;
 import java.time.Clock;
 import java.time.Instant;
@@ -22,6 +21,7 @@ import org.mockito.Mock;
 import org.molgenis.armadillo.TestSecurityConfig;
 import org.molgenis.armadillo.command.Commands;
 import org.molgenis.armadillo.metadata.ProfileService;
+import org.molgenis.armadillo.profile.DockerService;
 import org.molgenis.armadillo.storage.ArmadilloStorageService;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
@@ -43,7 +43,6 @@ class DevelopmentControllerTest extends ArmadilloControllerTestBase {
   @MockitoBean private ProfileService profileService;
   @MockitoBean private Commands commands;
   @MockitoBean private ArmadilloStorageService armadilloStorage;
-  @MockitoBean DockerClient dockerClient;
 
   @Mock(lenient = true)
   private Clock clock;
@@ -53,6 +52,7 @@ class DevelopmentControllerTest extends ArmadilloControllerTestBase {
   private final Instant instant = Instant.now();
   private String sessionId;
   private AuditEventValidator auditEventValidator;
+  @MockitoBean private DockerService dockerService;
 
   @BeforeEach
   public void setup() {
@@ -122,7 +122,7 @@ class DevelopmentControllerTest extends ArmadilloControllerTestBase {
   void testGetPackageNameFromFilename() {
     String filename = "hello_world_test.tar.gz";
     DevelopmentController controller =
-        new DevelopmentController(commands, auditEventPublisher, profileService);
+        new DevelopmentController(commands, auditEventPublisher, profileService, dockerService);
     String pkgName = controller.getPackageNameFromFilename(filename);
     assertEquals("hello_world", pkgName);
   }

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -368,7 +368,8 @@ class DockerServiceTest {
 
     // execute
     assertDoesNotThrow(() -> spyService.deleteProfile(profileName));
-  
+  }
+
   @Test
   void testGetDockerImages() {
     // Mock Docker images

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -233,7 +233,7 @@ class DockerServiceTest {
     when(inspectContainerResponse.getImageId()).thenReturn("sha256:same");
 
     // Call the method under test
-    dockerService.startProfile("default");
+    assertDoesNotThrow(() -> dockerService.startProfile("default"));
 
     // Verify no image removal called
     verify(dockerClient, never()).removeImageCmd(anyString());

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.armadillo.exceptions.ImageRemoveFailedException;
 import org.molgenis.armadillo.exceptions.MissingImageException;
 import org.molgenis.armadillo.metadata.ProfileConfig;
 import org.molgenis.armadillo.metadata.ProfileService;
@@ -202,7 +203,6 @@ class DockerServiceTest {
     // no containers use the old image
     var listCmd = mock(ListContainersCmd.class);
     when(dockerClient.listContainersCmd()).thenReturn(listCmd);
-    when(listCmd.withShowAll(true)).thenReturn(listCmd);
     when(listCmd.exec()).thenReturn(List.of());
 
     // image-removal by image ID
@@ -272,12 +272,10 @@ class DockerServiceTest {
 
     var listCmd = mock(ListContainersCmd.class);
     when(dockerClient.listContainersCmd()).thenReturn(listCmd);
-    when(listCmd.withShowAll(true)).thenReturn(listCmd);
     when(listCmd.exec()).thenReturn(List.of(container));
 
-    dockerService.removeImageIfUnused("sha256:inuse");
-
-    verify(dockerClient, never()).removeImageCmd(anyString());
+    assertThrows(
+        ImageRemoveFailedException.class, () -> dockerService.removeImageIfUnused("sha256:inuse"));
   }
 
   @Test
@@ -286,7 +284,6 @@ class DockerServiceTest {
 
     var listCmd = mock(ListContainersCmd.class);
     when(dockerClient.listContainersCmd()).thenReturn(listCmd);
-    when(listCmd.withShowAll(true)).thenReturn(listCmd);
     when(listCmd.exec()).thenReturn(List.of()); // not in use
 
     var rmCmd = mock(RemoveImageCmd.class);
@@ -307,7 +304,6 @@ class DockerServiceTest {
 
     var listCmd = mock(ListContainersCmd.class);
     when(dockerClient.listContainersCmd()).thenReturn(listCmd);
-    when(listCmd.withShowAll(true)).thenReturn(listCmd);
     when(listCmd.exec()).thenReturn(List.of()); // not in use
 
     when(dockerClient.inspectImageCmd(imageId)).thenThrow(new NotFoundException(""));

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -266,9 +266,22 @@ class DockerServiceTest {
   }
 
   @Test
-  void removeImageIfUnused_skipsWhenImageInUse() {
+  void removeImageIfUnused_throwsErrorWhenInUse() {
     var container = mock(Container.class);
     when(container.getImageId()).thenReturn("sha256:inuse");
+
+    var listCmd = mock(ListContainersCmd.class);
+    when(dockerClient.listContainersCmd()).thenReturn(listCmd);
+    when(listCmd.exec()).thenReturn(List.of(container));
+
+    assertThrows(
+        ImageRemoveFailedException.class, () -> dockerService.removeImageIfUnused("sha256:inuse"));
+  }
+
+  @Test
+  void removeImageIfUnused_throwsErrorWhenNoImage() {
+    var container = mock(Container.class);
+    when(container.getImageId()).thenThrow(NotFoundException.class);
 
     var listCmd = mock(ListContainersCmd.class);
     when(dockerClient.listContainersCmd()).thenReturn(listCmd);


### PR DESCRIPTION
how to test:
- Install armadillo locally
- Make sure docker is running with some images pulled in there
- Go to new swagger endpoint: http://localhost:8080/swagger-ui/index.html#/developer/deleteDockerImage
- Make sure there's an image in your local docker that isn't running and you want to delete, copy it's id (images tab in docker desktop and Image ID column)
- Paste the ID in the endpoint
- Click on Execute and see all images there (including non-running)

todo:
- [x] updated docs in case of new feature (swagger)
- [x] added tests
