### PR TITLE
feat: extra profile info

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -142,7 +142,8 @@ public class DevelopmentController {
             currentConfig.getLastImageId(),
             currentConfig.getVersionId(),
             currentConfig.getImageSize(),
-            currentConfig.getCreationDate());
+            currentConfig.getCreationDate(),
+            currentConfig.getInstallDate());
     auditEventPublisher.audit(
         () -> profiles.upsert(profileConfig),
         principal,

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -141,7 +141,8 @@ public class DevelopmentController {
             currentConfig.getOptions(),
             currentConfig.getLastImageId(),
             currentConfig.getVersionId(),
-            currentConfig.getImageSize());
+            currentConfig.getImageSize(),
+            currentConfig.getCreationDate());
     auditEventPublisher.audit(
         () -> profiles.upsert(profileConfig),
         principal,

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/DevelopmentController.java
@@ -140,7 +140,8 @@ public class DevelopmentController {
             currentConfig.getFunctionBlacklist(),
             currentConfig.getOptions(),
             currentConfig.getLastImageId(),
-            currentConfig.getVersionId());
+            currentConfig.getVersionId(),
+            currentConfig.getImageSize());
     auditEventPublisher.audit(
         () -> profiles.upsert(profileConfig),
         principal,

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ProfileResponse.java
@@ -49,6 +49,18 @@ public abstract class ProfileResponse {
   @JsonProperty("versionId") //
   public abstract String getVersionId();
 
+  @JsonProperty("imageSize")
+  @Nullable
+  public abstract Long getImageSize();
+
+  @JsonProperty("creationDate")
+  @Nullable
+  public abstract String getCreationDate();
+
+  @JsonProperty("installDate")
+  @Nullable
+  public abstract String getInstallDate();
+
   public static ProfileResponse create(ProfileConfig profileConfig, ContainerInfo containerInfo) {
     return new AutoValue_ProfileResponse(
         profileConfig.getName(),
@@ -62,6 +74,9 @@ public abstract class ProfileResponse {
         profileConfig.getOptions(),
         containerInfo,
         profileConfig.getLastImageId(),
-        profileConfig.getVersionId());
+        profileConfig.getVersionId(),
+        profileConfig.getImageSize(),
+        profileConfig.getCreationDate(),
+        profileConfig.getInstallDate());
   }
 }

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
@@ -32,6 +32,7 @@ public class InitialProfileConfig {
         functionBlacklist,
         options,
         null,
+        null,
         null);
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
@@ -33,6 +33,7 @@ public class InitialProfileConfig {
         options,
         null,
         null,
+        null,
         null);
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/InitialProfileConfig.java
@@ -34,6 +34,7 @@ public class InitialProfileConfig {
         null,
         null,
         null,
+        null,
         null);
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
@@ -59,6 +59,10 @@ public abstract class ProfileConfig {
   @Nullable
   public abstract String getVersionId();
 
+  @JsonProperty("imageSize")
+  @Nullable
+  public abstract Long getImageSize();
+
   @JsonCreator
   public static ProfileConfig create(
       @JsonProperty("name") String newName,
@@ -71,7 +75,8 @@ public abstract class ProfileConfig {
       @JsonProperty("functionBlacklist") Set<String> newFunctionBlacklist,
       @JsonProperty("options") Map<String, String> newOptions,
       @JsonProperty("lastImageId") @Nullable String newLastImageId,
-      @JsonProperty("versionId") @Nullable String newVersionId) {
+      @JsonProperty("versionId") @Nullable String newVersionId,
+      @JsonProperty("imageSize") @Nullable Long newImageSize) {
     return new AutoValue_ProfileConfig(
         newName,
         newImage,
@@ -83,7 +88,8 @@ public abstract class ProfileConfig {
         newFunctionBlacklist != null ? newFunctionBlacklist : Set.of(),
         newOptions != null ? newOptions : Map.of(),
         newLastImageId,
-        newVersionId);
+        newVersionId,
+        newImageSize);
   }
 
   public static ProfileConfig createDefault() {
@@ -97,6 +103,7 @@ public abstract class ProfileConfig {
         Set.of("dsBase"),
         emptySet(),
         Map.of("datashield.seed", "342325352"),
+        null,
         null,
         null);
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
@@ -67,6 +67,10 @@ public abstract class ProfileConfig {
   @Nullable
   public abstract String getCreationDate();
 
+  @JsonProperty("InstallDate")
+  @Nullable
+  public abstract String getInstallDate();
+
   @JsonCreator
   public static ProfileConfig create(
       @JsonProperty("name") String newName,
@@ -81,7 +85,8 @@ public abstract class ProfileConfig {
       @JsonProperty("lastImageId") @Nullable String newLastImageId,
       @JsonProperty("versionId") @Nullable String newVersionId,
       @JsonProperty("imageSize") @Nullable Long newImageSize,
-      @JsonProperty("creationDate") @Nullable String newCreationDate) {
+      @JsonProperty("creationDate") @Nullable String newCreationDate,
+      @JsonProperty("installDate") @Nullable String newInstallDate) {
     return new AutoValue_ProfileConfig(
         newName,
         newImage,
@@ -95,7 +100,8 @@ public abstract class ProfileConfig {
         newLastImageId,
         newVersionId,
         newImageSize,
-        newCreationDate);
+        newCreationDate,
+        newInstallDate);
   }
 
   public static ProfileConfig createDefault() {
@@ -109,6 +115,7 @@ public abstract class ProfileConfig {
         Set.of("dsBase"),
         emptySet(),
         Map.of("datashield.seed", "342325352"),
+        null,
         null,
         null,
         null,

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileConfig.java
@@ -63,6 +63,10 @@ public abstract class ProfileConfig {
   @Nullable
   public abstract Long getImageSize();
 
+  @JsonProperty("CreationDate")
+  @Nullable
+  public abstract String getCreationDate();
+
   @JsonCreator
   public static ProfileConfig create(
       @JsonProperty("name") String newName,
@@ -76,7 +80,8 @@ public abstract class ProfileConfig {
       @JsonProperty("options") Map<String, String> newOptions,
       @JsonProperty("lastImageId") @Nullable String newLastImageId,
       @JsonProperty("versionId") @Nullable String newVersionId,
-      @JsonProperty("imageSize") @Nullable Long newImageSize) {
+      @JsonProperty("imageSize") @Nullable Long newImageSize,
+      @JsonProperty("creationDate") @Nullable String newCreationDate) {
     return new AutoValue_ProfileConfig(
         newName,
         newImage,
@@ -89,7 +94,8 @@ public abstract class ProfileConfig {
         newOptions != null ? newOptions : Map.of(),
         newLastImageId,
         newVersionId,
-        newImageSize);
+        newImageSize,
+        newCreationDate);
   }
 
   public static ProfileConfig createDefault() {
@@ -103,6 +109,7 @@ public abstract class ProfileConfig {
         Set.of("dsBase"),
         emptySet(),
         Map.of("datashield.seed", "342325352"),
+        null,
         null,
         null,
         null);

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.molgenis.armadillo.exceptions.DefaultProfileDeleteException;
 import org.molgenis.armadillo.exceptions.UnknownProfileException;
 import org.molgenis.armadillo.profile.ProfileScope;
+import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
@@ -70,7 +71,8 @@ public class ProfileService {
                 profileConfig.getLastImageId(),
                 profileConfig.getVersionId(),
                 profileConfig.getImageSize(),
-                profileConfig.getCreationDate()));
+                profileConfig.getCreationDate(),
+                profileConfig.getInstallDate()));
     flushProfileBeans(profileName);
     save();
   }
@@ -121,7 +123,8 @@ public class ProfileService {
       String newImageId,
       String newVersionId,
       Long newImageSize,
-      String newCreationDate) {
+      String newCreationDate,
+      @Nullable String newInstallDate) {
     ProfileConfig existing = getByName(profileName);
 
     ProfileConfig updated =
@@ -138,7 +141,8 @@ public class ProfileService {
             newImageId,
             newVersionId,
             newImageSize,
-            newCreationDate);
+            newCreationDate,
+            newInstallDate != null ? newInstallDate : existing.getInstallDate());
 
     settings.getProfiles().put(profileName, updated);
     flushProfileBeans(profileName);

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -68,7 +68,8 @@ public class ProfileService {
                 profileConfig.getFunctionBlacklist(),
                 profileConfig.getOptions(),
                 profileConfig.getLastImageId(),
-                profileConfig.getVersionId()));
+                profileConfig.getVersionId(),
+                profileConfig.getImageSize()));
     flushProfileBeans(profileName);
     save();
   }
@@ -114,7 +115,8 @@ public class ProfileService {
     }
   }
 
-  public void updateImageMetaData(String profileName, String newImageId, String newVersionId) {
+  public void updateImageMetaData(
+      String profileName, String newImageId, String newVersionId, Long newImageSize) {
     ProfileConfig existing = getByName(profileName);
 
     ProfileConfig updated =
@@ -129,7 +131,8 @@ public class ProfileService {
             existing.getFunctionBlacklist(),
             existing.getOptions(),
             newImageId,
-            newVersionId);
+            newVersionId,
+            newImageSize);
 
     settings.getProfiles().put(profileName, updated);
     flushProfileBeans(profileName);

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ProfileService.java
@@ -69,7 +69,8 @@ public class ProfileService {
                 profileConfig.getOptions(),
                 profileConfig.getLastImageId(),
                 profileConfig.getVersionId(),
-                profileConfig.getImageSize()));
+                profileConfig.getImageSize(),
+                profileConfig.getCreationDate()));
     flushProfileBeans(profileName);
     save();
   }
@@ -116,7 +117,11 @@ public class ProfileService {
   }
 
   public void updateImageMetaData(
-      String profileName, String newImageId, String newVersionId, Long newImageSize) {
+      String profileName,
+      String newImageId,
+      String newVersionId,
+      Long newImageSize,
+      String newCreationDate) {
     ProfileConfig existing = getByName(profileName);
 
     ProfileConfig updated =
@@ -132,7 +137,8 @@ public class ProfileService {
             existing.getOptions(),
             newImageId,
             newVersionId,
-            newImageSize);
+            newImageSize,
+            newCreationDate);
 
     settings.getProfiles().put(profileName, updated);
     flushProfileBeans(profileName);

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -170,10 +170,34 @@ public class DockerService {
         LOG.info(e.getMessage());
       }
     }
+  }
 
-    String openContainersID = getOpenContainersImageVersion(currentImageId);
+  //  if (previousImageId == null && currentImageId != null) {
+  //    updateCreationDate
+  //  } else if (hasImageIdChanged(profileName, previousImageId, currentImageId)) {
+  //    updateCreationDate
+  //  }
+
+  void updateImageMetaData(String profileName, String currentImageId) {
+    String openContainersId = getOpenContainersImageVersion(currentImageId);
     Long imageSize = getImageSize(currentImageId);
-    profileService.updateImageMetaData(profileName, currentImageId, openContainersID, imageSize);
+    String creationDate = getImageCreationDate(currentImageId);
+    profileService.updateImageMetaData(
+        profileName, currentImageId, openContainersId, imageSize, creationDate);
+  }
+
+  String getImageCreationDate(String imageId) {
+    try {
+      return dockerClient
+          .inspectImageCmd(imageId)
+          .exec()
+          .getConfig()
+          .getLabels()
+          .get("org.opencontainers.image.created");
+    } catch (Exception e) {
+      LOG.error("Error retrieving creation date of image: {}", imageId, e);
+      return null;
+    }
   }
 
   Long getImageSize(String imageId) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -167,7 +167,17 @@ public class DockerService {
       }
     }
     String openContainersID = getOpenContainersImageVersion(currentImageId);
-    profileService.updateImageMetaData(profileName, currentImageId, openContainersID);
+    Long imageSize = getImageSize(currentImageId);
+    profileService.updateImageMetaData(profileName, currentImageId, openContainersID, imageSize);
+  }
+
+  Long getImageSize(String imageId) {
+    try {
+      return dockerClient.inspectImageCmd(imageId).exec().getSize();
+    } catch (Exception e) {
+      LOG.error("Error retrieving size of image: {}", imageId, e);
+      return null;
+    }
   }
 
   public String getOpenContainersImageVersion(String imageName) {

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -159,13 +159,18 @@ public class DockerService {
     String currentImageId =
         dockerClient.inspectContainerCmd(asContainerName(profileName)).exec().getImageId();
 
-    if (hasImageIdChanged(profileName, previousImageId, currentImageId)) {
+    if (previousImageId == null) {
+      LOG.info(
+          "No previous image ID recorded for {}. This may be the first run or from before image tracking was added.",
+          profileName);
+    } else if (hasImageIdChanged(profileName, previousImageId, currentImageId)) {
       try {
         removeImageIfUnused(previousImageId);
       } catch (ImageRemoveFailedException e) {
         LOG.info(e.getMessage());
       }
     }
+
     String openContainersID = getOpenContainersImageVersion(currentImageId);
     Long imageSize = getImageSize(currentImageId);
     profileService.updateImageMetaData(profileName, currentImageId, openContainersID, imageSize);

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -188,9 +188,6 @@ public class DockerService {
     } else {
       installDate = null;
     }
-    System.out.println("Previous imageId is: " + previousImageId);
-    System.out.println("Current imageId is: " + currentImageId);
-    System.out.println("Install date is: " + installDate);
     profileService.updateImageMetaData(
         profileName, currentImageId, openContainersId, imageSize, creationDate, installDate);
   }

--- a/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/profile/DockerService.java
@@ -15,6 +15,8 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.*;
 import jakarta.ws.rs.ProcessingException;
 import java.net.SocketException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -170,20 +172,27 @@ public class DockerService {
         LOG.info(e.getMessage());
       }
     }
+
+    updateImageMetaData(profileName, previousImageId, currentImageId);
   }
 
-  //  if (previousImageId == null && currentImageId != null) {
-  //    updateCreationDate
-  //  } else if (hasImageIdChanged(profileName, previousImageId, currentImageId)) {
-  //    updateCreationDate
-  //  }
-
-  void updateImageMetaData(String profileName, String currentImageId) {
+  void updateImageMetaData(String profileName, String previousImageId, String currentImageId) {
     String openContainersId = getOpenContainersImageVersion(currentImageId);
     Long imageSize = getImageSize(currentImageId);
     String creationDate = getImageCreationDate(currentImageId);
+
+    String installDate;
+    if ((previousImageId == null && currentImageId != null)
+        || hasImageIdChanged(profileName, previousImageId, currentImageId)) {
+      installDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
+    } else {
+      installDate = null;
+    }
+    System.out.println("Previous imageId is: " + previousImageId);
+    System.out.println("Current imageId is: " + currentImageId);
+    System.out.println("Install date is: " + installDate);
     profileService.updateImageMetaData(
-        profileName, currentImageId, openContainersId, imageSize, creationDate);
+        profileName, currentImageId, openContainersId, imageSize, creationDate, installDate);
   }
 
   String getImageCreationDate(String imageId) {

--- a/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
@@ -52,7 +52,8 @@ class DataShieldOptionsImplTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     options = new DataShieldOptionsImpl(profileConfig, packageService);
     ImmutableMap<String, String> packageOptions = ImmutableMap.of("a", "defaultA", "b", "defaultB");
     doReturn(rConnection).when(rConnectionFactory).tryCreateConnection();

--- a/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
@@ -51,7 +51,8 @@ class DataShieldOptionsImplTest {
             configOptions,
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     options = new DataShieldOptionsImpl(profileConfig, packageService);
     ImmutableMap<String, String> packageOptions = ImmutableMap.of("a", "defaultA", "b", "defaultB");
     doReturn(rConnection).when(rConnectionFactory).tryCreateConnection();

--- a/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/DataShieldOptionsImplTest.java
@@ -50,6 +50,7 @@ class DataShieldOptionsImplTest {
             emptySet(),
             configOptions,
             null,
+            null,
             null);
     options = new DataShieldOptionsImpl(profileConfig, packageService);
     ImmutableMap<String, String> packageOptions = ImmutableMap.of("a", "defaultA", "b", "defaultB");

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -253,7 +253,8 @@ class CommandsImplTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     when(profileService.getByName("exposome")).thenReturn(profileConfig);
     commands.selectProfile("exposome");
     verify(attrs).setAttribute("profile", "exposome", SCOPE_SESSION);

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -252,7 +252,8 @@ class CommandsImplTest {
             Map.of(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     when(profileService.getByName("exposome")).thenReturn(profileConfig);
     commands.selectProfile("exposome");
     verify(attrs).setAttribute("profile", "exposome", SCOPE_SESSION);

--- a/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/command/impl/CommandsImplTest.java
@@ -251,6 +251,7 @@ class CommandsImplTest {
             Set.of(),
             Map.of(),
             null,
+            null,
             null);
     when(profileService.getByName("exposome")).thenReturn(profileConfig);
     commands.selectProfile("exposome");

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
@@ -56,7 +56,8 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 emptyMap(),
                 null,
                 null,
-                null));
+                null,
+                newCreationDate));
     settings
         .getProfiles()
         .put(
@@ -73,7 +74,8 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 emptyMap(),
                 null,
                 null,
-                null));
+                null,
+                newCreationDate));
     return settings;
   }
 

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
@@ -55,6 +55,7 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 emptySet(),
                 emptyMap(),
                 null,
+                null,
                 null));
     settings
         .getProfiles()
@@ -70,6 +71,7 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 Set.of("dsBase", "dsOmics"),
                 emptySet(),
                 emptyMap(),
+                null,
                 null,
                 null));
     return settings;

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerDockServiceNullTest.java
@@ -57,7 +57,8 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 null,
                 null,
                 null,
-                newCreationDate));
+                null,
+                null));
     settings
         .getProfiles()
         .put(
@@ -75,7 +76,8 @@ class ProfilesControllerDockServiceNullTest extends ArmadilloControllerTestBase 
                 null,
                 null,
                 null,
-                newCreationDate));
+                null,
+                null));
     return settings;
   }
 

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -72,7 +72,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 null,
                 null,
                 null,
-                newCreationDate));
+                null,
+                null));
     settings
         .getProfiles()
         .put(
@@ -90,7 +91,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 null,
                 null,
                 null,
-                newCreationDate));
+                null,
+                null));
     return settings;
   }
 
@@ -134,7 +136,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
 
     mockMvc
         .perform(

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -70,6 +70,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 emptySet(),
                 emptyMap(),
                 null,
+                null,
                 null));
     settings
         .getProfiles()
@@ -85,6 +86,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 Set.of("dsBase", "dsOmics"),
                 emptySet(),
                 emptyMap(),
+                null,
                 null,
                 null));
     return settings;
@@ -127,6 +129,7 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
             Set.of("dsBase"),
             emptySet(),
             Map.of(),
+            null,
             null,
             null);
 

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ProfilesControllerTest.java
@@ -71,7 +71,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 emptyMap(),
                 null,
                 null,
-                null));
+                null,
+                newCreationDate));
     settings
         .getProfiles()
         .put(
@@ -88,7 +89,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
                 emptyMap(),
                 null,
                 null,
-                null));
+                null,
+                newCreationDate));
     return settings;
   }
 
@@ -131,7 +133,8 @@ class ProfilesControllerTest extends ArmadilloControllerTestBase {
             Map.of(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
 
     mockMvc
         .perform(

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
@@ -30,7 +30,8 @@ public class ProfileConfigTest {
             new HashMap<>(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     EnvironmentConfigProps actual = config.toEnvironmentConfigProps();
     assertEquals(img, actual.getImage());
   }
@@ -50,7 +51,8 @@ public class ProfileConfigTest {
             new HashMap<>(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     assertDoesNotThrow(config::toEnvironmentConfigProps);
   }
 
@@ -69,7 +71,8 @@ public class ProfileConfigTest {
             new HashMap<>(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     assertEquals("localhost", config.getHost());
   }
 
@@ -88,7 +91,8 @@ public class ProfileConfigTest {
             null,
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     assertEquals("java.util.ImmutableCollections$MapN", config.getOptions().getClass().getName());
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
@@ -31,7 +31,8 @@ public class ProfileConfigTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     EnvironmentConfigProps actual = config.toEnvironmentConfigProps();
     assertEquals(img, actual.getImage());
   }
@@ -52,7 +53,8 @@ public class ProfileConfigTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     assertDoesNotThrow(config::toEnvironmentConfigProps);
   }
 
@@ -72,7 +74,8 @@ public class ProfileConfigTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     assertEquals("localhost", config.getHost());
   }
 
@@ -92,7 +95,8 @@ public class ProfileConfigTest {
             null,
             null,
             null,
-            newCreationDate);
+            null,
+            null);
     assertEquals("java.util.ImmutableCollections$MapN", config.getOptions().getClass().getName());
   }
 }

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileConfigTest.java
@@ -29,6 +29,7 @@ public class ProfileConfigTest {
             new HashSet<>(),
             new HashMap<>(),
             null,
+            null,
             null);
     EnvironmentConfigProps actual = config.toEnvironmentConfigProps();
     assertEquals(img, actual.getImage());
@@ -48,6 +49,7 @@ public class ProfileConfigTest {
             new HashSet<>(),
             new HashMap<>(),
             null,
+            null,
             null);
     assertDoesNotThrow(config::toEnvironmentConfigProps);
   }
@@ -66,6 +68,7 @@ public class ProfileConfigTest {
             new HashSet<>(),
             new HashMap<>(),
             null,
+            null,
             null);
     assertEquals("localhost", config.getHost());
   }
@@ -82,6 +85,7 @@ public class ProfileConfigTest {
             6311,
             new HashSet<>(),
             new HashSet<>(),
+            null,
             null,
             null,
             null);

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
@@ -41,6 +41,7 @@ class ProfileServiceTest {
             null,
             null,
             null,
+            null,
             null);
     profilesMetadata.getProfiles().put("default", defaultProfile);
     var profilesLoader = new DummyProfilesLoader(profilesMetadata);
@@ -62,6 +63,7 @@ class ProfileServiceTest {
     String newVersionId = "0.0.1";
     Long newImageSize = 123_456_789L;
     String newCreationDate = "2025-08-05T12:34:56Z";
+    String newInstallDate = "2025-10-05T12:34:56Z";
 
     // Create an existing profile config with oldImageId
     ProfileConfig existingProfile =
@@ -76,6 +78,7 @@ class ProfileServiceTest {
             new HashSet<>(),
             Map.of(),
             oldImageId,
+            null,
             null,
             null,
             null);
@@ -97,7 +100,7 @@ class ProfileServiceTest {
 
     // Act: update the image id, version, and size
     profileService.updateImageMetaData(
-        profileName, newImageId, newVersionId, newImageSize, newCreationDate);
+        profileName, newImageId, newVersionId, newImageSize, newCreationDate, newInstallDate);
 
     // Assert that the profile has been updated
     ProfileConfig updated = profileService.getByName(profileName);

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
@@ -40,6 +40,7 @@ class ProfileServiceTest {
             new HashMap<>(),
             null,
             null,
+            null,
             null);
     profilesMetadata.getProfiles().put("default", defaultProfile);
     var profilesLoader = new DummyProfilesLoader(profilesMetadata);
@@ -59,7 +60,8 @@ class ProfileServiceTest {
     String oldImageId = "sha256:old";
     String newImageId = "sha256:new";
     String newVersionId = "0.0.1";
-    Long newImageSize = 123_456_789L; // ✅ Add image size
+    Long newImageSize = 123_456_789L;
+    String newCreationDate = "2025-08-05T12:34:56Z";
 
     // Create an existing profile config with oldImageId
     ProfileConfig existingProfile =
@@ -74,6 +76,7 @@ class ProfileServiceTest {
             new HashSet<>(),
             Map.of(),
             oldImageId,
+            null,
             null,
             null);
 
@@ -93,13 +96,14 @@ class ProfileServiceTest {
     profileService.initialize();
 
     // Act: update the image id, version, and size
-    profileService.updateImageMetaData(profileName, newImageId, newVersionId, newImageSize);
+    profileService.updateImageMetaData(
+        profileName, newImageId, newVersionId, newImageSize, newCreationDate);
 
     // Assert that the profile has been updated
     ProfileConfig updated = profileService.getByName(profileName);
     assertEquals(newImageId, updated.getLastImageId());
     assertEquals(newVersionId, updated.getVersionId());
-    assertEquals(newImageSize, updated.getImageSize()); // ✅ Check image size
+    assertEquals(newImageSize, updated.getImageSize());
 
     // Verify flush and save were called
     verify(mockProfileScope).removeAllProfileBeans(profileName);

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ProfileServiceTest.java
@@ -39,6 +39,7 @@ class ProfileServiceTest {
             Set.of(),
             new HashMap<>(),
             null,
+            null,
             null);
     profilesMetadata.getProfiles().put("default", defaultProfile);
     var profilesLoader = new DummyProfilesLoader(profilesMetadata);
@@ -53,11 +54,12 @@ class ProfileServiceTest {
   }
 
   @Test
-  void testUpdateLastImageId() {
+  void testUpdateMetaData() {
     String profileName = "default";
     String oldImageId = "sha256:old";
     String newImageId = "sha256:new";
     String newVersionId = "0.0.1";
+    Long newImageSize = 123_456_789L; // ✅ Add image size
 
     // Create an existing profile config with oldImageId
     ProfileConfig existingProfile =
@@ -72,6 +74,7 @@ class ProfileServiceTest {
             new HashSet<>(),
             Map.of(),
             oldImageId,
+            null,
             null);
 
     // Setup ProfilesMetadata and add existing profile
@@ -89,12 +92,14 @@ class ProfileServiceTest {
     ProfileService profileService = new ProfileService(loader, initialProfiles, mockProfileScope);
     profileService.initialize();
 
-    // Act: update the image id
-    profileService.updateImageMetaData(profileName, newImageId, newVersionId);
+    // Act: update the image id, version, and size
+    profileService.updateImageMetaData(profileName, newImageId, newVersionId, newImageSize);
 
     // Assert that the profile has been updated
     ProfileConfig updated = profileService.getByName(profileName);
     assertEquals(newImageId, updated.getLastImageId());
+    assertEquals(newVersionId, updated.getVersionId());
+    assertEquals(newImageSize, updated.getImageSize()); // ✅ Check image size
 
     // Verify flush and save were called
     verify(mockProfileScope).removeAllProfileBeans(profileName);

--- a/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/profile/DockerServiceTest.java
@@ -184,6 +184,9 @@ class DockerServiceTest {
     // Mock image size retrieval
     when(dockerService.getImageSize("sha256:abcd")).thenReturn(123_456_789L); // size in bytes
 
+    // Mock image creation date retrieval
+    when(dockerService.getImageCreationDate("sha256:abcd")).thenReturn("2025-08-05T12:34:56Z");
+
     dockerService.startProfile("default");
 
     // Verify Docker operations
@@ -194,7 +197,9 @@ class DockerServiceTest {
     verify(dockerClient).startContainerCmd("default");
 
     // Verify metadata update now includes image size
-    verify(profileService).updateImageMetaData("default", "sha256:abcd", "v1.0.0", 123_456_789L);
+    verify(profileService)
+        .updateImageMetaData(
+            "default", "sha256:abcd", "v1.0.0", 123_456_789L, "2025-08-05T12:34:56Z");
   }
 
   @Test
@@ -213,6 +218,9 @@ class DockerServiceTest {
 
     // ✅ Mock image size retrieval
     when(dockerService.getImageSize("sha256:new")).thenReturn(987_654_321L);
+
+    // Mock creation date retrieval
+    when(dockerService.getImageCreationDate("sha256:new")).thenReturn("2025-08-05T12:34:56Z");
 
     // Return tags — optional
     when(dockerClient.inspectImageCmd("sha256:old").exec().getRepoTags()).thenReturn(List.of());
@@ -237,7 +245,9 @@ class DockerServiceTest {
     verify(rmCmd).exec();
 
     // ✅ Updated verification includes image size
-    verify(profileService).updateImageMetaData("default", "sha256:new", "v1.0.0", 987_654_321L);
+    verify(profileService)
+        .updateImageMetaData(
+            "default", "sha256:new", "v1.0.0", 987_654_321L, "2025-08-05T12:34:56Z");
   }
 
   @Test
@@ -254,8 +264,11 @@ class DockerServiceTest {
     // Mock version retrieval
     when(dockerService.getOpenContainersImageVersion("sha256:same")).thenReturn("v1.0.0");
 
-    // ✅ Mock image size retrieval
+    // Mock image size retrieval
     when(dockerService.getImageSize("sha256:same")).thenReturn(555_000_000L);
+
+    // Mock creation date retrieval
+    when(dockerService.getImageCreationDate("sha256:new")).thenReturn("2025-08-05T12:34:56Z");
 
     // Call the method under test
     assertDoesNotThrow(() -> dockerService.startProfile("default"));
@@ -263,8 +276,10 @@ class DockerServiceTest {
     // Verify no image removal called
     verify(dockerClient, never()).removeImageCmd(anyString());
 
-    // ✅ Verify metadata update now includes image size
-    verify(profileService).updateImageMetaData("default", "sha256:same", "v1.0.0", 555_000_000L);
+    // Verify metadata update now includes image size
+    verify(profileService)
+        .updateImageMetaData(
+            "default", "sha256:same", "v1.0.0", 555_000_000L, "2025-08-05T12:34:56Z");
   }
 
   private List<ProfileConfig> createExampleSettings() {
@@ -282,7 +297,8 @@ class DockerServiceTest {
             emptyMap(),
             null,
             null,
-            null);
+            null,
+            newCreationDate);
     return List.of(profile1, profile2);
   }
 

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -65,6 +65,9 @@ export type Profile = {
   name: string;
   image: string;
   versionId?: string;
+  imageSize?: number;
+  creationDate?: string;
+  installDate?: string;
   host: string;
   port: number;
   packageWhitelist: StringArray;
@@ -79,6 +82,12 @@ export type Profile = {
   };
   autoUpdate?: boolean;
   autoUpdateSchedule?: AutoUpdateSchedule;
+};
+
+type FormattedProfile = Profile & {
+  formattedImageSize: string;
+  formattedCreationDate: string;
+  formattedInstallDate: string;
 };
 
 export type Auth = { user: string; pwd: string };

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -369,7 +369,6 @@ export default defineComponent({
         InstallDate: "string",
         autoUpdate: "boolean",
         autoUpdateSchedule: "object",
-        host: "string",
         port: "string",
         packageWhitelist: "array",
         functionBlacklist: "array",

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -381,10 +381,19 @@ export default defineComponent({
         columns["container"] = "object";
       }
 
+      const toHideInEdit = [
+        "container",
+        "autoUpdateSchedule",
+        "versionId",
+        "ImageSize",
+        "CreationDate",
+        "installDate",
+      ];
+
       if (this.profileToEditIndex !== -1) {
-        delete columns.container;
-        delete columns.autoUpdateSchedule;
-        delete columns.versionId;
+        toHideInEdit.forEach((key) => {
+          delete columns[key as keyof TypeObject];
+        });
       }
 
       return columns;

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -278,13 +278,13 @@ export default defineComponent({
               },
               ImageSize: profile.imageSize
                 ? convertBytes(profile.imageSize)
-                : "N/A",
+                : "",
               CreationDate: profile.creationDate
-                ? new Date(profile.creationDate).toLocaleString()
-                : "N/A",
+                ? new Date(profile.creationDate).toLocaleDateString()
+                : "",
               InstallDate: profile.installDate
-                ? new Date(profile.installDate).toLocaleString()
-                : "N/A",
+                ? new Date(profile.installDate).toLocaleDateString()
+                : "",
             };
           });
         })

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -387,7 +387,7 @@ export default defineComponent({
         "versionId",
         "ImageSize",
         "CreationDate",
-        "installDate",
+        "InstallDate",
       ];
 
       if (this.profileToEditIndex !== -1) {


### PR DESCRIPTION
## Background
Now that we are automatically updating profiles, we want to include more information about the profiles installed.

## How to test
- Check that the columns "Version ID", "Image Size", "Creation Date" and "Install Date" are showing
- Add a new profile (or start an existing profile), and check that these fields are populated with information. Note that 
"Version ID" and "Creation Date" depend on these properties being set in the profile, so they may not show depending the profile you are starting.



