### PR TITLE
feat: hide schedule when autoupdate not selected

### DIFF
--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -101,7 +101,11 @@
           </div>
         </div>
         <div
-          v-else-if="objectProps.row.autoUpdateSchedule === objectProps.data"
+          v-else-if="
+            objectProps.row.autoUpdate &&
+            objectProps.data &&
+            objectProps.data.frequency
+          "
         >
           <span>
             {{
@@ -111,6 +115,15 @@
             }}
           </span>
         </div>
+        <div
+          v-else-if="
+            !objectProps.row.autoUpdate &&
+            objectProps.data &&
+            'frequency' in objectProps.data &&
+            'day' in objectProps.data &&
+            'time' in objectProps.data
+          "
+        ></div>
         <div v-else>
           <div v-for="(value, key) in objectProps.data" :key="key">
             {{ key }} = {{ value }}


### PR DESCRIPTION
## How to test
- On the profiles tab, edit a profile
- Check that in edit mode the 'auto update schedule' column disapears
- Check that if you click 'autoupdate' in edit mode the schedule information appears below, and disappears again if 'auto-update' is untoggled