### PR TITLE
refactor: apply formatting using table slot

### DIFF
--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -404,9 +404,9 @@ export default defineComponent({
         "container",
         "autoUpdateSchedule",
         "versionId",
-        "ImageSize",
-        "CreationDate",
-        "InstallDate",
+        "imageSize",
+        "creationDate",
+        "installDate",
       ];
 
       if (this.profileToEditIndex !== -1) {


### PR DESCRIPTION
how to test:
- Add a new profile and save it
- In the brower, go to 'inspect` -> `network`
- Refresh the page
- Check that in 'insepect/network' the values for imageSize, creationDate and installDate are shown unformatted (ie we don't want to see 4.6gb)
- Check that in the UI nothing weird is shown like 'Invalid date'