### PR TITLE
style: make table content smaller to spread out profiles page better …

### DIFF
--- a/ui/src/components/ProfileStatus.vue
+++ b/ui/src/components/ProfileStatus.vue
@@ -1,13 +1,8 @@
 <template>
-  <button class="btn btn-link pt-0 pb-0 mt-1 status" :disabled="disabled">
-    <div>
-      <LoadingSpinner
-        imageWidth="30"
-        v-if="icon === 'spinner'"
-      ></LoadingSpinner>
-      <h3 v-else class="p-0 m-0"><i :class="`bi bi-${icon}`"></i></h3>
-      <span>{{ text }}</span>
-    </div>
+  <button class="btn btn-link p-0 mt-1 status btn-sm" :disabled="disabled">
+    <LoadingSpinner imageWidth="30" v-if="icon === 'spinner'"></LoadingSpinner>
+    <h3 v-else class="p-0 m-0"><i :class="`bi bi-${icon}`"></i></h3>
+    <span>{{ text }}</span>
   </button>
 </template>
 
@@ -39,6 +34,6 @@ export default defineComponent({
 
 <style scoped>
 .status {
-  width: 8rem;
+  width: 6rem;
 }
 </style>

--- a/ui/src/components/Table.vue
+++ b/ui/src/components/Table.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="table">
+  <table class="table" :class="isSmall ? 'table-sm' : ''">
     <thead>
       <tr>
         <slot name="extraHeader"></slot>
@@ -106,6 +106,10 @@ export default defineComponent({
     highlightedRowIndex: {
       type: Number,
       default: -1,
+    },
+    isSmall: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -26,6 +26,7 @@
       :allData="profiles"
       :indexToEdit="profileToEditIndex"
       :dataStructure="profilesDataStructure"
+      :isSmall="true"
     >
       <template v-slot:extraHeader>
         <!-- Add extra header for buttons (add profile button) -->
@@ -46,11 +47,11 @@
             objectProps.data &&
             statusMapping[objectProps.data.status as keyof typeof statusMapping]
           "
-          class="row"
+          class="row p-0"
         >
-          <div class="col-6">
+          <div class="col-6 p-0">
             <span
-              class="badge"
+              class="badge mt-3"
               :class="`bg-${
                 statusMapping[
                   objectProps.data.status as keyof typeof statusMapping
@@ -64,7 +65,7 @@
               }}
             </span>
           </div>
-          <div class="col-6">
+          <div class="col-6 p-0">
             <ProfileStatus
               :disabled="true"
               v-if="objectProps.row.name === loadingProfile"
@@ -616,3 +617,9 @@ export default defineComponent({
   },
 });
 </script>
+
+<style :scoped>
+* {
+  box-sizing: content-box !important;
+}
+</style>


### PR DESCRIPTION
…on small screens

how to test:
- go to preview
- open profiles page on smaller screen
- table content still fits in screen

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
