### PR TITLE
fix: error when previewing parquet files on docker (snappy error)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ VOLUME /data
 VOLUME /config
 VOLUME /logs
 
+RUN apk update && apk add --no-cache libc6-compat
+
 ARG JAR_FILE
 EXPOSE 8080
 COPY ${JAR_FILE} /app.jar


### PR DESCRIPTION
how to test:
- Go to preview
- Go to projects
- Select project that's there
- Preview file in project
- Table preview shows
- No error occurs (before you'd get api error)
