### PR TITLE
build: Add docker Scout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
       - run:
           name: Docker-Scout scanning on cves, break on critical.
           command: |
+            export $( cat build/ci.properties | xargs )
             docker scout cves molgenis/molgenis-armadillo-snapshot:${TAG_NAME} --exit-code --only-severity critical
 
 


### PR DESCRIPTION
Add docker security scan to build process and stop build after finding critical updates.
