### PR TITLE
fix: #950 cannot set auto update

### DIFF
--- a/ui/src/views/Profiles.vue
+++ b/ui/src/views/Profiles.vue
@@ -305,7 +305,7 @@ export default defineComponent({
             return {
               ...profile,
               datashieldSeed,
-              autoUpdateSchedule: profile.autoUpdateSchedule || {
+              updateSchedule: profile.updateSchedule || {
                 frequency: "weekly",
                 day: "Sunday",
                 time: "01:00",


### PR DESCRIPTION
how to test:
- Check your `profiles.json`, make sure there's at least one that doesn't have an `updateSchedule` variable
- Start armadillo
- Go to profiles page
- Edit the profile without updateSchedule
- Check auto update
- Now you should be able to select daily/weekly and if weekly, a day (before, the selection options wouldn't be there and page might even go blank)
