### PR TITLE
chore: bump spring and api dependencies

### DIFF
--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.15.5'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.16.4'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework:spring-aspects'
@@ -46,8 +46,8 @@ dependencies {
     //other
     implementation 'org.rosuda.REngine:REngine:2.1.0'
     implementation 'org.rosuda.REngine:Rserve:1.8.1'
-    implementation 'io.swagger.core.v3:swagger-annotations:2.2.30'
-    implementation("io.swagger.core.v3:swagger-core-jakarta:2.2.30")
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.45'
+    implementation("io.swagger.core.v3:swagger-core-jakarta:2.2.45")
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
     implementation 'org.obiba.datashield:ds4j-core:2.1.0'
     implementation 'org.obiba.datashield:ds4j-r:2.1.0'
@@ -59,7 +59,7 @@ dependencies {
     implementation("org.apache.parquet:parquet-avro:1.15.1")
     implementation("org.apache.parquet:parquet-common:1.15.1")
     implementation("com.opencsv:opencsv:5.10")
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
     //Overrides docker-java's sub-dependency to fix compatibility issues with apple ARM chips
     //https://github.com/docker-java/docker-java/issues/1876 -->

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
  * - ui/build.gradle
  */
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.11'
     id "io.spring.dependency-management" version "1.1.7"
     id "java"
     id "org.sonarqube" version "4.4.1.3373"


### PR DESCRIPTION
  Body:
  ## Summary
  - org.springframework.boot 3.5.6 → 3.5.11
  - micrometer-registry-prometheus 1.15.5 → 1.16.4
  - swagger-annotations + swagger-core-jakarta 2.2.30 → 2.2.45
  - springdoc-openapi-starter-webmvc-ui 2.7.0 → 2.8.16

  ## How to test
  - [ ] Build passes (`./gradlew clean build`)
  - [ ] Application starts
  - [ ] Release tests pass (`./release-test.R`)
  - [ ] UI works (if impacted)