### PR TITLE
chore: bump apache dependencies

### DIFF
--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -54,10 +54,10 @@ dependencies {
     implementation 'com.github.docker-java:docker-java:3.5.0'
     implementation 'com.github.docker-java:docker-java-transport-zerodep:3.5.0'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
-    implementation 'org.apache.parquet:parquet-hadoop:1.16.0'
-    implementation 'org.apache.hadoop:hadoop-client:3.4.2'
-    implementation("org.apache.parquet:parquet-avro:1.15.1")
-    implementation("org.apache.parquet:parquet-common:1.15.1")
+    implementation 'org.apache.parquet:parquet-hadoop:1.17.0'
+    implementation 'org.apache.hadoop:hadoop-client:3.4.3'
+    implementation("org.apache.parquet:parquet-avro:1.17.0")
+    implementation("org.apache.parquet:parquet-common:1.17.0")
     implementation("com.opencsv:opencsv:5.10")
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     implementation 'org.rosuda.REngine:Rserve:1.8.1'
     implementation 'com.google.guava:guava:33.1.0-jre'
     implementation 'com.google.auto.value:auto-value-annotations:1.10.4'
-    implementation 'org.apache.commons:commons-text:1.11.0'
+    implementation 'org.apache.commons:commons-text:1.15.0'
     implementation 'org.json:json:20240303'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.6'
 
     //test
     testImplementation('org.springframework.boot:spring-boot-starter-test') {


### PR DESCRIPTION
  Body:
  ## Summary
  - parquet-hadoop 1.16.0 → 1.17.0
  - parquet-avro 1.15.1 → 1.17.0
  - parquet-common 1.15.1 → 1.17.0
  - hadoop-client 3.4.2 → 3.4.3
  - commons-io 2.15.1 → 2.21.0
  - commons-text 1.11.0 → 1.15.0
  - httpclient5 5.3.1 → 5.6

  ## How to test
  - [ ] Build passes (`./gradlew clean build`)
  - [ ] Application starts
  - [ ] Release tests pass (`./release-test.R`)
  - [ ] UI works (if impacted)