### PR TITLE
chore: bump CI/CD github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,16 +9,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache


### PR DESCRIPTION
  ## Summary
  - actions/checkout v4 → v6
  - actions/setup-python v5 → v6
  - actions/cache v4 → v5

Note: `molgenis/ci-build` base image bump (1.2.4 → ?) is deferred — Renovate suggests 1.5.1 but Docker Hub only has up to 1.3.3. 

  ## How to test
  - [ ] CI docs workflow passes on this PR