### PR TITLE
Chore/bump gradle major

### DIFF
--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.spring.dependency-management'
     id "jacoco"
     id "java"
-    id "com.diffplug.spotless" version "6.25.0"
+    id "com.diffplug.spotless" version "8.0.0"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ plugins {
     id 'application'
     id "jacoco"
     id 'com.palantir.docker' version '0.36.0'
-    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
-    id 'com.github.ben-manes.versions' version '0.51.0'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.19'
+    id 'com.github.ben-manes.versions' version '0.53.0'
 }
 
 targetCompatibility = '21'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.6'
     id "io.spring.dependency-management" version "1.1.7"
     id "java"
-    id "org.sonarqube" version "4.4.1.3373"
+    id "org.sonarqube" version "7.2.3.7755"
     id 'maven-publish'
     id 'application'
     id "jacoco"
@@ -23,8 +23,10 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.53.0'
 }
 
-targetCompatibility = '21'
-sourceCompatibility = '21'
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 println "Project previous version (nyx): " + rootProject.nyxState.releaseScope.previousVersion
 
@@ -92,7 +94,6 @@ String getGitNameRef() {
 }
 
 // configure artifact
-mainClassName = 'org.molgenis.armadillo.ArmadilloServiceApplication'
 dependencies {
     implementation project(':armadillo')
 }
@@ -104,7 +105,7 @@ springBoot {
     buildInfo()
 }
 bootJar {
-    mainClass = mainClassName
+    mainClass = 'org.molgenis.armadillo.ArmadilloServiceApplication'
     manifest {
         attributes(
                 'Specification-Version': project.version.toString(),
@@ -119,7 +120,7 @@ bootJar {
 
 //define run
 application {
-    mainClass.set(rootProject.mainClassName)
+    mainClass.set('org.molgenis.armadillo.ArmadilloServiceApplication')
 }
 
 //define release
@@ -134,7 +135,7 @@ if (version.toString().endsWith('-SNAPSHOT')) {
     tagName = "${project.version.toString()}-${ext.hash}"
 }
 task ci(type: WriteProperties) {
-    outputFile file('build/ci.properties')
+    destinationFile = file('build/ci.properties')
     property 'TAG_NAME', tagName
 }
 
@@ -189,7 +190,9 @@ sonar {
 task installLocalGitHook(type: Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
     into { new File(rootProject.rootDir, '.git/hooks') }
-    fileMode 0775
+    filePermissions {
+        unix('0775')
+    }
 }
 build.dependsOn installLocalGitHook
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
     id 'maven-publish'
     id 'application'
     id "jacoco"
-    id 'com.palantir.docker' version '0.36.0'
     id 'se.patrikerdes.use-latest-versions' version '0.2.19'
     id 'com.github.ben-manes.versions' version '0.53.0'
 }
@@ -139,14 +138,17 @@ task ci(type: WriteProperties) {
     property 'TAG_NAME', tagName
 }
 
-docker {
-    name imageName
-    tags tagName
-    dockerfile file('Dockerfile')
-    files bootJar.archiveFile
-    buildArgs(['JAR_FILE': "${bootJar.archiveFile.get().asFile.name}"])
+task docker(type: Exec, dependsOn: bootJar) {
+    commandLine 'docker', 'build',
+        '-t', "${imageName}:${tagName}",
+        '--build-arg', "JAR_FILE=build/libs/${bootJar.archiveFile.get().asFile.name}",
+        '-f', 'Dockerfile',
+        '.'
 }
-dockerPrepare.dependsOn bootJar
+
+task dockerPush(type: Exec, dependsOn: docker) {
+    commandLine 'docker', 'push', "${imageName}:${tagName}"
+}
 
 //merge test reports
 task jacocoMergedReport(type: JacocoReport) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "jacoco"
     id "java"
-    id "com.diffplug.spotless" version "6.25.0"
+    id "com.diffplug.spotless" version "8.0.0"
     id 'org.springframework.boot'
     id 'io.spring.dependency-management'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 // Installed here as advised to load before all other
 // @see https://mooltiverse.github.io/nyx/guide/user/quick-start/gradle-plugin/#apply-the-plugin
 plugins {
-    id "com.mooltiverse.oss.nyx" version "2.5.2"
+    id "com.mooltiverse.oss.nyx" version "3.0.7"
 }
 
 //nyx is our release plugin

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "base"
-    id "com.github.node-gradle.node" version "7.0.2"
+    id "com.github.node-gradle.node" version "7.1.0"
 }
 
 def nodeSpec = {


### PR DESCRIPTION
  ## Summary
  - Gradle 8.8 → 9.4.0
  - Replaced com.palantir.docker plugin (unmaintained, incompatible with Gradle 8.12+) with simple Exec tasks that call `docker build` and `docker push` directly
  - org.sonarqube 4.4.1.3373 → 7.2.3.7755
  - com.diffplug.spotless 6.25.0 → 8.0.0
  - com.mooltiverse.oss.nyx 2.5.2 → 3.0.7
  - se.patrikerdes.use-latest-versions 0.2.18 → 0.2.19
  - com.github.ben-manes.versions 0.51.0 → 0.53.0
  - com.github.node-gradle.node 7.0.2 → 7.1.0

  ### Gradle 9 migration changes
  - Removed deprecated `mainClassName` property, inlined class name into `bootJar` and `application` blocks
  - Replaced `WriteProperties.outputFile()` with `destinationFile`
  - Replaced `Copy.fileMode` with `filePermissions { unix('0775') }`

  ## How to test
  - [ ] Build passes (`./gradlew clean build`)
  - [ ] `./gradlew docker` builds the Docker image successfully
  - [ ] Application starts
  - [ ] Release tests pass (`./release-test.R`)
  - [ ] CI pipeline passes