### PR TITLE
test: fix expected error to work for rock and rserver

### DIFF
--- a/scripts/release/testthat/tests/test-10-resources.R
+++ b/scripts/release/testthat/tests/test-10-resources.R
@@ -94,7 +94,7 @@ test_that("/objects/ (iii): resource file accessible, data inaccessible - assign
       symbol = "old_iii_resolved",
       expr = as.symbol("as.resource.object(old_iii)")
     ),
-    "invalid first argument",
+    "invalid first argument|valor ausente",
     info = "/objects/: researcher must have access to data project to resolve"
   )
 })

--- a/scripts/release/testthat/tests/test-10-resources.R
+++ b/scripts/release/testthat/tests/test-10-resources.R
@@ -94,7 +94,7 @@ test_that("/objects/ (iii): resource file accessible, data inaccessible - assign
       symbol = "old_iii_resolved",
       expr = as.symbol("as.resource.object(old_iii)")
     ),
-    "invalid first argument|valor ausente",
+    "There are some DataSHIELD errors", ## Generic because rserver and rock return different error messages
     info = "/objects/: researcher must have access to data project to resolve"
   )
 })


### PR DESCRIPTION
## Background
There is one resource test on which both rserve and rock give the same behaviour (error message), but the content of the error message differs, which makes the test fail for rserver.

## What's changed
Broaden the regex so the test passes on failure with either error message

## How to test
- [ ] Run release test on Armadillo for `donkey` profile
- [ ] Run release test on Armadillo for `socker` profile (`datashield/rserver_soccer-donkey:latest`)
- [ ] Check CI green