### PR TITLE
chore: bump tomcat version because of CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ allprojects {
     version = version.replace("v","")
 }
 
+ext['tomcat.version'] = '10.1.53'
+
 if(getGitNameRef().contains("tags/") && !getGitNameRef().contains("~")) {
     def x = getGitNameRef().replace("tags/", "")
     println "HEAD is on tag so removing SNAPSHOT: " + x


### PR DESCRIPTION
## Background
Vulnerability announced last week, causing CI to fail on all branches:
https://nvd.nist.gov/vuln/detail/CVE-2026-29145

## What's changed
Bumped version of tomcat

## How to test
- [ ] Check CI now passes