### PR TITLE
fix: date preview

### DIFF
--- a/ui/src/helpers/utils.ts
+++ b/ui/src/helpers/utils.ts
@@ -126,20 +126,7 @@ export function isInt(itemToCheck: number) {
 }
 
 export function isIntArray(listOfItems: StringArray) {
-  let itemIsIntArray = true;
-  listOfItems.forEach((item) => {
-    if (!isDate(item)) {
-      const numberToCheck = parseFloat(item);
-      if (!isInt(numberToCheck)) {
-        itemIsIntArray = false;
-        return;
-      }
-    } else {
-      itemIsIntArray = false;
-      return;
-    }
-  });
-  return itemIsIntArray;
+    return listOfItems.every((item) => isInt(Number(item)));
 }
 
 export function isDate(item: string) {

--- a/ui/tests/unit/helpers/utils.spec.ts
+++ b/ui/tests/unit/helpers/utils.spec.ts
@@ -152,6 +152,41 @@ describe("utils", () => {
       const actual = isIntArray(["test1", "test2", "test3"]);
       expect(actual).toBe(false);
     });
+    // Date columns must NOT be treated as integer columns: parseFloat reads a
+    // numeric prefix (e.g. "10/12/2005" -> 10), which previously misclassified
+    // these as ints and caused parseInt to display only the leading number.
+    it("should return false for slash dates dd/mm/yyyy", () => {
+      const actual = isIntArray(["10/12/2005", "15/01/2024", "31/12/2023"]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for slash dates mm/dd/yyyy", () => {
+      const actual = isIntArray(["01/15/2024", "02/09/2024", "12/31/2023"]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for slash dates yyyy/mm/dd", () => {
+      const actual = isIntArray(["2024/01/15", "2024/02/09", "2023/12/31"]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for dash dates dd-mm-yyyy", () => {
+      const actual = isIntArray(["15-01-2024", "09-02-2024", "31-12-2023"]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for ISO dates yyyy-mm-dd", () => {
+      const actual = isIntArray(["2024-01-15", "2024-02-09", "2023-12-31"]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for ISO datetimes without timezone", () => {
+      const actual = isIntArray([
+        "2024-01-15T13:45:30",
+        "2024-02-09T08:05:00",
+        "2023-12-31T23:59:59",
+      ]);
+      expect(actual).toBe(false);
+    });
+    it("should return false for dashed month-abbreviation dates", () => {
+      const actual = isIntArray(["15-Jan-2024", "09-Feb-2024", "31-Dec-2023"]);
+      expect(actual).toBe(false);
+    });
   });
 
   describe("transformTable", () => {


### PR DESCRIPTION
 ## Background
  Uploaded tables with date columns (e.g. `10/12/2005`) displayed corrupted in the UI data preview — only the leading number (`10`) showed. Root cause: `isIntArray` used `parseFloat`, which parses a numeric *prefix*, so date columns were misclassified as integer columns and rendered with `parseInt`.

  ## What's changed
  - `ui/src/helpers/utils.ts`: `isIntArray` now uses `Number()` (whole-string parse) instead of `parseFloat()` (prefix parse), simplified to a single `Array.every`. Date strings are converted to NaN` and not treated as ints; genuine ints and whole floats like `"1.0"` are unchanged.
  - Added unit tests for `isIntArray` covering ISO, slash (`d/m/y`, `m/d/y`, `y/m/d`), dash, and dashed-month date formats.

  ## How to test
- [x] Code review
- [x] Check new unit tests pass
- [x] Manual UI test:

1. Save this as dates.csv:
  id,name,dob,visits
  1,Ana,10/12/2005,3
  2,Ben,01/02/1998,7
  3,Cara,2024-01-15,1
  4,Dan,15-03-1990,12
  5,Eve,30/11/2012,0
  6,Finn,07/07/2007,5
  7,Gail,1985-06-22,9
  8,Hugo,21/09/2001,2
  9,Ivy,03/03/2033,4
  10,Jack,12/12/2012,6

2. In the UI, upload it via the CSV importer
3. Open Data preview.
    - Before: dob shows 10, 01, 2024, 15, …
    - After (this PR): dob shows the full dates (10/12/2005, 2024-01-15, 15-03-1990, …); id and visits still render as integers.