### PR TITLE
feat: leading zeros string

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/storage/CharacterSeparatedFile.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/storage/CharacterSeparatedFile.java
@@ -118,7 +118,7 @@ public class CharacterSeparatedFile {
     try {
       double d = Double.parseDouble(cell);
       if ((d == Math.floor(d)) && !Double.isInfinite(d) && !cell.contains(".")) {
-        return CharacterSeparatedFile.INT;
+        return hasLeadingZero(cell) ? CharacterSeparatedFile.STRING : CharacterSeparatedFile.INT;
       } else {
         return CharacterSeparatedFile.DOUBLE;
       }
@@ -133,6 +133,11 @@ public class CharacterSeparatedFile {
         return CharacterSeparatedFile.STRING;
       }
     }
+  }
+
+  static boolean hasLeadingZero(String cell) {
+    String digits = (cell.startsWith("-") || cell.startsWith("+")) ? cell.substring(1) : cell;
+    return digits.length() > 1 && digits.charAt(0) == '0';
   }
 
   static String getTypeToSet(String type, String currentType) {

--- a/armadillo/src/test/java/org/molgenis/armadillo/storage/CharacterSeparatedFileTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/storage/CharacterSeparatedFileTest.java
@@ -44,6 +44,35 @@ class CharacterSeparatedFileTest {
   }
 
   @Test
+  void testConstructorStoresLeadingZeroColumnAsString() throws IOException, CsvValidationException {
+    String csvData = "id,age\n001,30\n002,25\n";
+    Mockito.when(mockFile.getInputStream())
+        .thenReturn(new ByteArrayInputStream(csvData.getBytes()));
+    Mockito.when(mockFile.getOriginalFilename()).thenReturn("test.csv");
+
+    CharacterSeparatedFile csf = new CharacterSeparatedFile(mockFile);
+
+    assertEquals(
+        List.of(CharacterSeparatedFile.STRING, CharacterSeparatedFile.INT), csf.getTypes());
+  }
+
+  @Test
+  void testConstructorMixedLeadingZeroColumnStaysString()
+      throws IOException, CsvValidationException {
+    // a column mixing a plain int and a leading-zero value must resolve to string for the
+    // whole column so no leading zeros are lost
+    String csvData = "id,age\n1,30\n002,25\n";
+    Mockito.when(mockFile.getInputStream())
+        .thenReturn(new ByteArrayInputStream(csvData.getBytes()));
+    Mockito.when(mockFile.getOriginalFilename()).thenReturn("test.csv");
+
+    CharacterSeparatedFile csf = new CharacterSeparatedFile(mockFile);
+
+    assertEquals(
+        List.of(CharacterSeparatedFile.STRING, CharacterSeparatedFile.INT), csf.getTypes());
+  }
+
+  @Test
   void testErrorThrownWhenSchemaCannotBeCreated() throws IOException {
     String csvData = "name of person,age\nJohn,30\nJane,25\n";
     Mockito.when(mockFile.getInputStream())
@@ -97,6 +126,14 @@ class CharacterSeparatedFileTest {
   @Test
   void testGetTypeOfCellInt() {
     assertEquals(CharacterSeparatedFile.INT, CharacterSeparatedFile.getTypeOfCell("1"));
+    assertEquals(CharacterSeparatedFile.INT, CharacterSeparatedFile.getTypeOfCell("0"));
+  }
+
+  @Test
+  void testGetTypeOfCellLeadingZeroIsString() {
+    assertEquals(CharacterSeparatedFile.STRING, CharacterSeparatedFile.getTypeOfCell("001"));
+    assertEquals(CharacterSeparatedFile.STRING, CharacterSeparatedFile.getTypeOfCell("08028"));
+    assertEquals(CharacterSeparatedFile.STRING, CharacterSeparatedFile.getTypeOfCell("-007"));
   }
 
   @Test

--- a/ui/src/helpers/utils.ts
+++ b/ui/src/helpers/utils.ts
@@ -125,8 +125,15 @@ export function isInt(itemToCheck: number) {
   return itemToCheck % 1 === 0;
 }
 
+export function hasLeadingZero(item: string) {
+  const digits = /^[+-]/.test(item) ? item.slice(1) : item;
+  return digits.length > 1 && digits.startsWith("0");
+}
+
 export function isIntArray(listOfItems: StringArray) {
-    return listOfItems.every((item) => isInt(Number(item)));
+  return listOfItems.every(
+    (item) => isInt(Number(item)) && !hasLeadingZero(item)
+  );
 }
 
 export function isDate(item: string) {

--- a/ui/tests/unit/helpers/utils.spec.ts
+++ b/ui/tests/unit/helpers/utils.spec.ts
@@ -187,6 +187,22 @@ describe("utils", () => {
       const actual = isIntArray(["15-Jan-2024", "09-Feb-2024", "31-Dec-2023"]);
       expect(actual).toBe(false);
     });
+    it("should return false for values with leading zeros", () => {
+      const actual = isIntArray(["001", "002", "010"]);
+      expect(actual).toBe(false);
+    });
+    it("should return true for genuine ints including a single zero", () => {
+      const actual = isIntArray(["0", "3", "12"]);
+      expect(actual).toBe(true);
+    });
+    it("should return false for signed values with leading zeros", () => {
+      const actual = isIntArray(["+004", "-007"]);
+      expect(actual).toBe(false);
+    });
+    it("should return true for signed ints without leading zeros", () => {
+      const actual = isIntArray(["-7", "+5"]);
+      expect(actual).toBe(true);
+    });
   });
 
   describe("transformTable", () => {


### PR DESCRIPTION
## Background

Columns containing leading zeros (e.g. participant IDs `001`, `002`, or postcodes like   `08028`) were being inferred as integers during CSV→Parquet conversion. On write, `Integer.parseInt("001")` returns `1`, so the leading zeros were permanently lost in the stored Parquet file — when the data was downloaded and loaded in R, `001` came back as `1`. Fixes #1027.

## What's changed
- `CharacterSeparatedFile.getTypeOfCell` now classifies an integer-looking value with a significant leading zero as `string` instead of `int`, so the column is stored as a string and the zeros survive the round-trip.
- Added a `hasLeadingZero` helper: strips an optional `+`/`-` sign, then treats a `0` followed by at least one more digit as significant (`"0"` → false, `"00"`/`"001"`/`"-007"` → true). Plain ints (`"0"`, `"5"`) and decimals (`"0.5"`, handled by the    `double` branch) are unaffected.
- The existing `getTypeToSet` logic already makes `string` absorbing, so a column mixing `1` and `002` resolves to `string` for the whole column — no per-cell zero loss.
- Tests in `CharacterSeparatedFileTest` for: leading-zero classification (incl. signed), `"0"` staying `int`, and constructor-level checks for a pure and a mixed leading-zero column.

## How to test
- [ ] Code review
- [ ] Check unit tests pass
- [ ] Manual test:

1. Create new project `csv_zeros`
2. Create folder `data`
3. Save this as a .csv (`test_zeros.csv`)

```id,age
001,30
002,25
00501,40
```
Login via R and download the table:

```
library(MolgenisArmadillo)
armadillo.load_table("csv_zeros", "data", "test_zeros.csv")
```
Check that the `id` column has the leading zeros intact.
