### PR TITLE
docs: change get_token to get_credentials

### DIFF
--- a/docs/pages/basic_usage/ds_molgenis_armadillo.md
+++ b/docs/pages/basic_usage/ds_molgenis_armadillo.md
@@ -30,8 +30,8 @@ For more detailed information please visit [DSMolgenisArmadillo](https://molgeni
         # specify server url
         armadillo_url <- "https://armadillo.test.molgenis.org"
 
-        # get token from central authentication server
-        token <- armadillo.get_token(armadillo_url)
+        # get credentials from central authentication server
+        token <- armadillo.get_credentials(armadillo_url)
 
 
         # build the login dataframe
@@ -39,7 +39,7 @@ For more detailed information please visit [DSMolgenisArmadillo](https://molgeni
         builder$append(
             server = "armadillo",
             url = armadillo_url,
-            token = token,
+            token = token@access_token,
             table = "workshop1/2_1-core-1_0/nonrep",
             driver = "ArmadilloDriver"
         )

--- a/docs/pages/basic_usage/molgenis_armadillo.md
+++ b/docs/pages/basic_usage/molgenis_armadillo.md
@@ -50,7 +50,7 @@ Below some basic operations to get you started using MolgenisArmadillo:
         armadillo.login(
             armadillo = "https://armadillo.test.molgenis.org"
         )
-        #token <- armadillo.get_token("https://armadillo.test.molgenis.org")
+        #token <- armadillo.get_credentials("https://armadillo.test.molgenis.org")
 
         # armadillo.login will create a session and store the credentials in the environment.
 

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -56,11 +56,11 @@
     library(MolgenisArmadillo)
     library(resourcer)
 
-    token <- armadillo.get_token("http://localhost:8080/")
+    token <- armadillo.get_credentials("http://localhost:8080/")
 
     resGSE1 <- resourcer::newResource(
       name = "GSE66351_1",
-      secret = token,
+      secret = token@access_token,
       url = "http://host.docker.internal:8080/storage/projects/omics/objects/test%2Fgse66351_1.rda",
       format = "ExpressionSet"
     )
@@ -73,13 +73,13 @@
     library(DSMolgenisArmadillo)
     library(dsBaseClient)
 
-    token <- armadillo.get_token("http://localhost:8080/")
+    token <- armadillo.get_credentials("http://localhost:8080/")
 
     builder <- DSI::newDSLoginBuilder()
     builder$append(
       server = "local",
       url = "http://localhost:8080/",
-      token = token,
+      token = token@access_token,
       driver = "ArmadilloDriver",
       profile = "uniform",
       resource = "omics/ewas/GSE66351_1"

--- a/docs/pages/quick_start.md
+++ b/docs/pages/quick_start.md
@@ -84,13 +84,13 @@ library(dsBaseClient)
 With these libraries, you can now login to Armadillo. Note - here we don't specify a profile so you will log in to the default profile. If there is a specific profile you want to connect to you can specify this with the argument e.g. `profile = donkey`.
 ```R
 url <- "https://armadillo-playground.molgenis.net//"
-token <- armadillo.get_token(url)
+token <- armadillo.get_credentials(url)
 builder <- DSI::newDSLoginBuilder()
 
 builder$append(
   server = "armadillo",
   url = url,
-  token = token,
+  token = token@access_token,
   driver = "ArmadilloDriver")
   
 logindata <- builder$build()

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -38,4 +38,4 @@ dsTidyverse, remove-data, basic-auth
 
 ### CICD 
 - Note CICD only runs test as admin as we cannot connect to an OIDC account.
-- Using `armadillo.get_token` will run locally but fail at CICD.
+- Using `armadillo.get_credentials` will run locally but fail at CICD.


### PR DESCRIPTION
## Background
We made `armadillo.get_token` defunct but did not update all docs.

## What's changed
All references to `armadillo.get_token` replaced with `armadillo.get_credentials`.

## How to test:
Read through docs and check changes in reference to `armadillo.get_token` are correct. Changes should be:
-` token <- armadillo.get_token(xxx) `--> `credentials <- armadillo.get_token(xxx)`
- `secret/token = token` --> `secret/token = credentials@access_token`