### PR TITLE
feat(flwr) #003: whitelist config

### DIFF
--- a/armadillo/build.gradle
+++ b/armadillo/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation("org.apache.parquet:parquet-common:1.17.1")
     implementation("com.opencsv:opencsv:5.10")
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
     //Overrides docker-java's sub-dependency to fix compatibility issues with apple ARM chips
     //https://github.com/docker-java/docker-java/issues/1876 -->

--- a/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
@@ -65,6 +65,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String LIST_CONTAINERS_STATUS = "LIST_CONTAINERS_STATUS";
   public static final String UPSERT_CONTAINER = "UPSERT_CONTAINER";
   public static final String DELETE_CONTAINER = "DELETE_CONTAINER";
+  public static final String ADD_FAB_WHITELIST_ENTRY = "ADD_FAB_WHITELIST_ENTRY";
   public static final String GET_CONTAINER = "GET_CONTAINER";
   public static final String START_CONTAINER = "START_CONTAINER";
   public static final String STOP_CONTAINER = "STOP_CONTAINER";

--- a/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/audit/AuditEventPublisher.java
@@ -97,6 +97,9 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware {
   public static final String SYMBOL = "symbol";
   public static final String PROJECT = "project";
   public static final String CONTAINER = "container";
+  public static final String FAB_ID = "fabId";
+  public static final String FAB_VERSION = "fabVersion";
+  public static final String FAB_HASH = "fabHash";
   public static final String OBJECT = "object";
   public static final String EMAIL = "email";
   public static final String MESSAGE = "message";

--- a/armadillo/src/main/java/org/molgenis/armadillo/container/FlowerSuperexecContainerConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/container/FlowerSuperexecContainerConfig.java
@@ -58,6 +58,9 @@ public abstract class FlowerSuperexecContainerConfig
   @Nullable
   public abstract String getFabWhitelistPath();
 
+  @Nullable
+  public abstract List<WhitelistedApp> getFabWhitelist();
+
   @Override
   @JsonIgnore
   public String getType() {
@@ -77,7 +80,8 @@ public abstract class FlowerSuperexecContainerConfig
       @JsonProperty("dockerOptions") @Nullable Map<String, Object> dockerOptions,
       @JsonProperty("versionId") @Nullable String versionId,
       @JsonProperty("creationDate") @Nullable String creationDate,
-      @JsonProperty("fabWhitelistPath") @Nullable String fabWhitelistPath) {
+      @JsonProperty("fabWhitelistPath") @Nullable String fabWhitelistPath,
+      @JsonProperty("fabWhitelist") @Nullable List<WhitelistedApp> fabWhitelist) {
 
     return builder()
         .name(name)
@@ -92,6 +96,7 @@ public abstract class FlowerSuperexecContainerConfig
         .versionId(versionId)
         .creationDate(creationDate)
         .fabWhitelistPath(fabWhitelistPath)
+        .fabWhitelist(fabWhitelist)
         .build();
   }
 
@@ -128,16 +133,24 @@ public abstract class FlowerSuperexecContainerConfig
 
     public abstract Builder fabWhitelistPath(@Nullable String fabWhitelistPath);
 
+    public abstract Builder fabWhitelist(@Nullable List<WhitelistedApp> fabWhitelist);
+
     abstract String getName();
 
     @Nullable
     abstract String getFabWhitelistPath();
+
+    @Nullable
+    abstract List<WhitelistedApp> getFabWhitelist();
 
     abstract FlowerSuperexecContainerConfig autoBuild();
 
     public FlowerSuperexecContainerConfig build() {
       if (getFabWhitelistPath() == null) {
         fabWhitelistPath("data/system/flower/" + getName() + "-fab-whitelist.yaml");
+      }
+      if (getFabWhitelist() == null) {
+        fabWhitelist(List.of());
       }
       return autoBuild();
     }

--- a/armadillo/src/main/java/org/molgenis/armadillo/container/WhitelistedApp.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/container/WhitelistedApp.java
@@ -1,0 +1,3 @@
+package org.molgenis.armadillo.container;
+
+public record WhitelistedApp(String fabId, String fabVersion, String fabHash) {}

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ContainersController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ContainersController.java
@@ -1,6 +1,7 @@
 package org.molgenis.armadillo.controller;
 
 import static java.util.Objects.requireNonNull;
+import static org.molgenis.armadillo.audit.AuditEventPublisher.ADD_FAB_WHITELIST_ENTRY;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.CONTAINER;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.DELETE_CONTAINER;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.GET_CONTAINER;
@@ -31,6 +32,7 @@ import org.molgenis.armadillo.metadata.ContainerService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -216,6 +218,36 @@ public class ContainersController {
         principal,
         UPSERT_CONTAINER,
         Map.of(CONTAINER, containerConfig));
+  }
+
+  @Operation(summary = "Add or replace a FAB-hash whitelist entry on a Flower clientapp container")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "Whitelist entry added or replaced"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid fabId, fabVersion or fabHash",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(hidden = true)))
+      })
+  @PostMapping(value = "{name}/fab-whitelist", produces = TEXT_PLAIN_VALUE)
+  @ResponseStatus(NO_CONTENT)
+  public void addFabWhitelistEntry(
+      Principal principal,
+      @PathVariable String name,
+      @Valid @RequestBody FabWhitelistEntryRequest request) {
+    auditor.audit(
+        () -> {
+          containers.addFabWhitelistEntry(
+              name, request.fabId(), request.fabVersion(), request.fabHash());
+          return null;
+        },
+        principal,
+        ADD_FAB_WHITELIST_ENTRY,
+        Map.of(CONTAINER, name));
   }
 
   @Operation(

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/ContainersController.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/ContainersController.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.ADD_FAB_WHITELIST_ENTRY;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.CONTAINER;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.DELETE_CONTAINER;
+import static org.molgenis.armadillo.audit.AuditEventPublisher.FAB_HASH;
+import static org.molgenis.armadillo.audit.AuditEventPublisher.FAB_ID;
+import static org.molgenis.armadillo.audit.AuditEventPublisher.FAB_VERSION;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.GET_CONTAINER;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.LIST_CONTAINERS;
 import static org.molgenis.armadillo.audit.AuditEventPublisher.LIST_CONTAINERS_STATUS;
@@ -247,7 +250,15 @@ public class ContainersController {
         },
         principal,
         ADD_FAB_WHITELIST_ENTRY,
-        Map.of(CONTAINER, name));
+        Map.of(
+            CONTAINER,
+            name,
+            FAB_ID,
+            request.fabId(),
+            FAB_VERSION,
+            request.fabVersion(),
+            FAB_HASH,
+            request.fabHash()));
   }
 
   @Operation(

--- a/armadillo/src/main/java/org/molgenis/armadillo/controller/FabWhitelistEntryRequest.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/controller/FabWhitelistEntryRequest.java
@@ -1,0 +1,6 @@
+package org.molgenis.armadillo.controller;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FabWhitelistEntryRequest(
+    @NotBlank String fabId, @NotBlank String fabVersion, @NotBlank String fabHash) {}

--- a/armadillo/src/main/java/org/molgenis/armadillo/exceptions/InvalidFabWhitelistEntryException.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/exceptions/InvalidFabWhitelistEntryException.java
@@ -1,0 +1,13 @@
+package org.molgenis.armadillo.exceptions;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(BAD_REQUEST)
+public class InvalidFabWhitelistEntryException extends RuntimeException {
+
+  public InvalidFabWhitelistEntryException(String message) {
+    super(message);
+  }
+}

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static org.molgenis.armadillo.container.ActiveContainerNameAccessor.DEFAULT;
 import static org.molgenis.armadillo.security.RunAs.runAsSystem;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,9 +15,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.molgenis.armadillo.container.*;
 import org.molgenis.armadillo.exceptions.DefaultContainerDeleteException;
+import org.molgenis.armadillo.exceptions.InvalidFabWhitelistEntryException;
 import org.molgenis.armadillo.exceptions.UnknownContainerException;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -23,6 +28,13 @@ import org.springframework.stereotype.Service;
 @Service
 @PreAuthorize("hasRole('ROLE_SU')")
 public class ContainerService {
+
+  private static final Pattern FAB_HASH_PATTERN = Pattern.compile("^[a-fA-F0-9]{64}$");
+  private static final Pattern FAB_ID_PATTERN = Pattern.compile("^@[\\w-]+/[\\w-]+$");
+
+  private static final ObjectMapper FAB_WHITELIST_YAML_MAPPER =
+      new ObjectMapper(new YAMLFactory())
+          .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
   private final ContainersLoader loader;
   private final InitialContainerConfigs initialContainer;
@@ -80,6 +92,7 @@ public class ContainerService {
       createPlaceholderFiles(supernode);
     } else if (containerConfig instanceof FlowerSuperexecContainerConfig superexec) {
       createPlaceholderFiles(superexec);
+      writeFabWhitelistFile(superexec);
     }
 
     settings.getContainers().put(containerName, containerConfig);
@@ -106,6 +119,61 @@ public class ContainerService {
       Files.createFile(path);
     } catch (IOException e) {
       throw new IllegalStateException("Failed to create placeholder file: " + path, e);
+    }
+  }
+
+  /**
+   * Overwrites the FAB whitelist file with the config's current {@code fabWhitelist}, so the file a
+   * SuperExec container reads always matches what's stored in {@code containers.json}.
+   */
+  private void writeFabWhitelistFile(FlowerSuperexecContainerConfig config) {
+    try {
+      FAB_WHITELIST_YAML_MAPPER.writeValue(
+          Path.of(config.getFabWhitelistPath()).toFile(), config.getFabWhitelist());
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Failed to write FAB whitelist file: " + config.getFabWhitelistPath(), e);
+    }
+  }
+
+  /**
+   * Adds or replaces an approved app on a Flower SuperExec container's FAB-hash whitelist. Replaces
+   * any existing entry for the same {@code (fabId, fabVersion)} — re-approving a declared version
+   * supersedes its previous hash rather than accumulating a second one.
+   */
+  public void addFabWhitelistEntry(
+      String containerName, String fabId, String fabVersion, String fabHash) {
+    ContainerConfig existing = getByName(containerName);
+
+    if (!(existing instanceof FlowerSuperexecContainerConfig superexec)) {
+      throw new IllegalArgumentException(
+          "Container '" + containerName + "' is not a Flower clientapp container");
+    }
+
+    validateFabHash(fabHash);
+    validateFabId(fabId);
+
+    List<WhitelistedApp> updatedWhitelist =
+        superexec.getFabWhitelist().stream()
+            .filter(
+                entry -> !(entry.fabId().equals(fabId) && entry.fabVersion().equals(fabVersion)))
+            .collect(Collectors.toCollection(ArrayList::new));
+    updatedWhitelist.add(new WhitelistedApp(fabId, fabVersion, fabHash));
+
+    upsert(superexec.toBuilder().fabWhitelist(updatedWhitelist).build());
+  }
+
+  private void validateFabHash(String fabHash) {
+    if (!FAB_HASH_PATTERN.matcher(fabHash).matches()) {
+      throw new InvalidFabWhitelistEntryException(
+          "fabHash must be a 64-character hexadecimal SHA-256 hash, got: " + fabHash);
+    }
+  }
+
+  private void validateFabId(String fabId) {
+    if (!FAB_ID_PATTERN.matcher(fabId).matches()) {
+      throw new InvalidFabWhitelistEntryException(
+          "fabId must look like '@publisher/name', got: " + fabId);
     }
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
@@ -30,7 +30,12 @@ import org.springframework.stereotype.Service;
 public class ContainerService {
 
   private static final Pattern FAB_HASH_PATTERN = Pattern.compile("^[a-fA-F0-9]{64}$");
-  private static final Pattern FAB_ID_PATTERN = Pattern.compile("^@[\\w-]+/[\\w-]+$");
+  // Matches Flower's own fab_id format (publisher/name — see
+  // get_metadata_from_config in flwr.cli.config_utils), which has no leading
+  // "@". The "@" only appears in Hub *specifiers* (@account/app, used in
+  // `flwr run`/`fetch-fab` calls), never in a FAB's own declared metadata —
+  // confirmed against a real FAB, not assumed.
+  private static final Pattern FAB_ID_PATTERN = Pattern.compile("^[\\w-]+/[\\w-]+$");
 
   private static final ObjectMapper FAB_WHITELIST_YAML_MAPPER =
       new ObjectMapper(new YAMLFactory())
@@ -173,7 +178,7 @@ public class ContainerService {
   private void validateFabId(String fabId) {
     if (!FAB_ID_PATTERN.matcher(fabId).matches()) {
       throw new InvalidFabWhitelistEntryException(
-          "fabId must look like '@publisher/name', got: " + fabId);
+          "fabId must look like 'publisher/name', got: " + fabId);
     }
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -30,11 +31,6 @@ import org.springframework.stereotype.Service;
 public class ContainerService {
 
   private static final Pattern FAB_HASH_PATTERN = Pattern.compile("^[a-fA-F0-9]{64}$");
-  // Matches Flower's own fab_id format (publisher/name — see
-  // get_metadata_from_config in flwr.cli.config_utils), which has no leading
-  // "@". The "@" only appears in Hub *specifiers* (@account/app, used in
-  // `flwr run`/`fetch-fab` calls), never in a FAB's own declared metadata —
-  // confirmed against a real FAB, not assumed.
   private static final Pattern FAB_ID_PATTERN = Pattern.compile("^[\\w-]+/[\\w-]+$");
 
   private static final ObjectMapper FAB_WHITELIST_YAML_MAPPER =
@@ -97,7 +93,6 @@ public class ContainerService {
       createPlaceholderFiles(supernode);
     } else if (containerConfig instanceof FlowerSuperexecContainerConfig superexec) {
       createPlaceholderFiles(superexec);
-      writeFabWhitelistFile(superexec);
     }
 
     settings.getContainers().put(containerName, containerConfig);
@@ -127,10 +122,6 @@ public class ContainerService {
     }
   }
 
-  /**
-   * Overwrites the FAB whitelist file with the config's current {@code fabWhitelist}, so the file a
-   * SuperExec container reads always matches what's stored in {@code containers.json}.
-   */
   private void writeFabWhitelistFile(FlowerSuperexecContainerConfig config) {
     try {
       FAB_WHITELIST_YAML_MAPPER.writeValue(
@@ -141,11 +132,6 @@ public class ContainerService {
     }
   }
 
-  /**
-   * Adds or replaces an approved app on a Flower SuperExec container's FAB-hash whitelist. Replaces
-   * any existing entry for the same {@code (fabId, fabVersion)} — re-approving a declared version
-   * supersedes its previous hash rather than accumulating a second one.
-   */
   public void addFabWhitelistEntry(
       String containerName, String fabId, String fabVersion, String fabHash) {
     ContainerConfig existing = getByName(containerName);
@@ -157,15 +143,21 @@ public class ContainerService {
 
     validateFabHash(fabHash);
     validateFabId(fabId);
+    validateFabVersion(fabVersion);
 
     List<WhitelistedApp> updatedWhitelist =
         superexec.getFabWhitelist().stream()
             .filter(
-                entry -> !(entry.fabId().equals(fabId) && entry.fabVersion().equals(fabVersion)))
+                entry ->
+                    !(entry.fabId().equals(fabId)
+                        && Objects.equals(entry.fabVersion(), fabVersion)))
             .collect(Collectors.toCollection(ArrayList::new));
     updatedWhitelist.add(new WhitelistedApp(fabId, fabVersion, fabHash));
 
-    upsert(superexec.toBuilder().fabWhitelist(updatedWhitelist).build());
+    FlowerSuperexecContainerConfig updated =
+        superexec.toBuilder().fabWhitelist(updatedWhitelist).build();
+    upsert(updated);
+    writeFabWhitelistFile(updated);
   }
 
   private void validateFabHash(String fabHash) {
@@ -179,6 +171,12 @@ public class ContainerService {
     if (!FAB_ID_PATTERN.matcher(fabId).matches()) {
       throw new InvalidFabWhitelistEntryException(
           "fabId must look like 'publisher/name', got: " + fabId);
+    }
+  }
+
+  private void validateFabVersion(String fabVersion) {
+    if (fabVersion == null || fabVersion.isBlank()) {
+      throw new InvalidFabWhitelistEntryException("fabVersion must not be blank");
     }
   }
 

--- a/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/metadata/ContainerService.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
 import org.molgenis.armadillo.container.*;
 import org.molgenis.armadillo.exceptions.DefaultContainerDeleteException;
 import org.molgenis.armadillo.exceptions.InvalidFabWhitelistEntryException;
+import org.molgenis.armadillo.exceptions.NotFlowerSuperexecContainerException;
 import org.molgenis.armadillo.exceptions.UnknownContainerException;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -86,28 +88,41 @@ public class ContainerService {
   }
 
   public void upsert(ContainerConfig containerConfig) {
+    store(keepStoredFabWhitelist(containerConfig));
+  }
 
+  private void store(ContainerConfig containerConfig) {
     String containerName = containerConfig.getName();
 
     if (containerConfig instanceof FlowerSupernodeContainerConfig supernode) {
       createPlaceholderFiles(supernode);
-    } else if (containerConfig instanceof FlowerSuperexecContainerConfig superexec) {
-      createPlaceholderFiles(superexec);
     }
 
     settings.getContainers().put(containerName, containerConfig);
 
     flushContainerBeans(containerName);
     save();
+
+    // Written after saving, so a failed write leaves the app blocked rather than allowed.
+    if (containerConfig instanceof FlowerSuperexecContainerConfig superexec) {
+      writeFabWhitelistFile(superexec);
+    }
+  }
+
+  // The whitelist changes only through addFabWhitelistEntry. A general container
+  // save, such as from the UI, does not include it, so keep the stored one.
+  private ContainerConfig keepStoredFabWhitelist(ContainerConfig containerConfig) {
+    if (containerConfig instanceof FlowerSuperexecContainerConfig superexec
+        && settings.getContainers().get(superexec.getName())
+            instanceof FlowerSuperexecContainerConfig stored) {
+      return superexec.toBuilder().fabWhitelist(stored.getFabWhitelist()).build();
+    }
+    return containerConfig;
   }
 
   private void createPlaceholderFiles(FlowerSupernodeContainerConfig config) {
     createFileIfNotExists(config.getCaCertPath());
     createFileIfNotExists(config.getAuthPrivateKeyPath());
-  }
-
-  private void createPlaceholderFiles(FlowerSuperexecContainerConfig config) {
-    createFileIfNotExists(config.getFabWhitelistPath());
   }
 
   private void createFileIfNotExists(String pathStr) {
@@ -123,9 +138,10 @@ public class ContainerService {
   }
 
   private void writeFabWhitelistFile(FlowerSuperexecContainerConfig config) {
+    Path path = Path.of(config.getFabWhitelistPath());
     try {
-      FAB_WHITELIST_YAML_MAPPER.writeValue(
-          Path.of(config.getFabWhitelistPath()).toFile(), config.getFabWhitelist());
+      Files.createDirectories(path.toAbsolutePath().getParent());
+      FAB_WHITELIST_YAML_MAPPER.writeValue(path.toFile(), config.getFabWhitelist());
     } catch (IOException e) {
       throw new IllegalStateException(
           "Failed to write FAB whitelist file: " + config.getFabWhitelistPath(), e);
@@ -137,13 +153,14 @@ public class ContainerService {
     ContainerConfig existing = getByName(containerName);
 
     if (!(existing instanceof FlowerSuperexecContainerConfig superexec)) {
-      throw new IllegalArgumentException(
-          "Container '" + containerName + "' is not a Flower clientapp container");
+      throw new NotFlowerSuperexecContainerException(containerName);
     }
 
     validateFabHash(fabHash);
     validateFabId(fabId);
     validateFabVersion(fabVersion);
+    // Flower's hashes are lower case and the SuperExec plugin compares them exactly.
+    String normalisedHash = fabHash.toLowerCase(Locale.ROOT);
 
     List<WhitelistedApp> updatedWhitelist =
         superexec.getFabWhitelist().stream()
@@ -152,12 +169,9 @@ public class ContainerService {
                     !(entry.fabId().equals(fabId)
                         && Objects.equals(entry.fabVersion(), fabVersion)))
             .collect(Collectors.toCollection(ArrayList::new));
-    updatedWhitelist.add(new WhitelistedApp(fabId, fabVersion, fabHash));
+    updatedWhitelist.add(new WhitelistedApp(fabId, fabVersion, normalisedHash));
 
-    FlowerSuperexecContainerConfig updated =
-        superexec.toBuilder().fabWhitelist(updatedWhitelist).build();
-    upsert(updated);
-    writeFabWhitelistFile(updated);
+    store(superexec.toBuilder().fabWhitelist(updatedWhitelist).build());
   }
 
   private void validateFabHash(String fabHash) {

--- a/armadillo/src/test/java/org/molgenis/armadillo/container/FlowerContainerConfigSerializationTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/container/FlowerContainerConfigSerializationTest.java
@@ -189,8 +189,8 @@ class FlowerContainerConfigSerializationTest {
             .image("timmyjc/superexec-test:0.0.1")
             .fabWhitelist(
                 List.of(
-                    new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64)),
-                    new WhitelistedApp("@publisher/other-app", "2.1.0", "b".repeat(64))))
+                    new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64)),
+                    new WhitelistedApp("publisher/other-app", "2.1.0", "b".repeat(64))))
             .build();
 
     String json = OBJECT_MAPPER.writeValueAsString(original);

--- a/armadillo/src/test/java/org/molgenis/armadillo/container/FlowerContainerConfigSerializationTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/container/FlowerContainerConfigSerializationTest.java
@@ -171,6 +171,36 @@ class FlowerContainerConfigSerializationTest {
   }
 
   @Test
+  void superexecDefaultsFabWhitelistToEmptyList() {
+    FlowerSuperexecContainerConfig config =
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-project-1")
+            .image("timmyjc/superexec-test:0.0.1")
+            .build();
+
+    assertEquals(List.of(), config.getFabWhitelist());
+  }
+
+  @Test
+  void superexecWithFabWhitelistRoundTrips() throws Exception {
+    FlowerSuperexecContainerConfig original =
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-project-1")
+            .image("timmyjc/superexec-test:0.0.1")
+            .fabWhitelist(
+                List.of(
+                    new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64)),
+                    new WhitelistedApp("@publisher/other-app", "2.1.0", "b".repeat(64))))
+            .build();
+
+    String json = OBJECT_MAPPER.writeValueAsString(original);
+    FlowerSuperexecContainerConfig deserialized =
+        OBJECT_MAPPER.readValue(json, FlowerSuperexecContainerConfig.class);
+
+    assertEquals(original, deserialized);
+  }
+
+  @Test
   void flowerConfigsAreNotUpdatableContainers() {
     FlowerSupernodeContainerConfig supernode =
         FlowerSupernodeContainerConfig.builder().name("sn").image("flwr/supernode:1.26.1").build();

--- a/armadillo/src/test/java/org/molgenis/armadillo/controller/ContainersControllerTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/controller/ContainersControllerTest.java
@@ -3,6 +3,7 @@ package org.molgenis.armadillo.controller;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.molgenis.armadillo.security.RunAs.runAsSystem;
@@ -10,16 +11,19 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.molgenis.armadillo.TestSecurityConfig;
 import org.molgenis.armadillo.container.*;
 import org.molgenis.armadillo.metadata.*;
@@ -216,6 +220,80 @@ class ContainersControllerTest extends ArmadilloControllerTestBase {
     mockMvc
         .perform(put("/containers").content(json).contentType(APPLICATION_JSON).with(csrf()))
         .andExpect(status().isNoContent()); // Should now return 204
+  }
+
+  @Test
+  @WithMockUser(roles = "SU")
+  void addFabWhitelistEntry_POST(@TempDir Path tempDir) throws Exception {
+    runAsSystem(
+        () ->
+            containerService.upsert(
+                FlowerSuperexecContainerConfig.builder()
+                    .name("flower-clientapp-1")
+                    .image("flwr/superexec:1.32.1")
+                    .fabWhitelistPath(tempDir.resolve("fab-whitelist.yaml").toString())
+                    .build()));
+
+    String json =
+        "{\"fabId\":\"publisher/app\",\"fabVersion\":\"1.0.0\",\"fabHash\":\""
+            + "a".repeat(64)
+            + "\"}";
+
+    mockMvc
+        .perform(
+            post("/containers/flower-clientapp-1/fab-whitelist")
+                .content(json)
+                .contentType(APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    var updated =
+        (FlowerSuperexecContainerConfig)
+            runAsSystem(() -> containerService.getByName("flower-clientapp-1"));
+    assertEquals(
+        List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))),
+        updated.getFabWhitelist());
+  }
+
+  @Test
+  @WithMockUser(roles = "SU")
+  void addFabWhitelistEntry_POST_rejectsInvalidEntry(@TempDir Path tempDir) throws Exception {
+    runAsSystem(
+        () ->
+            containerService.upsert(
+                FlowerSuperexecContainerConfig.builder()
+                    .name("flower-clientapp-1")
+                    .image("flwr/superexec:1.32.1")
+                    .fabWhitelistPath(tempDir.resolve("fab-whitelist.yaml").toString())
+                    .build()));
+
+    String json =
+        "{\"fabId\":\"not-an-app-id\",\"fabVersion\":\"1.0.0\",\"fabHash\":\"not-a-hash\"}";
+
+    mockMvc
+        .perform(
+            post("/containers/flower-clientapp-1/fab-whitelist")
+                .content(json)
+                .contentType(APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = "SU")
+  void addFabWhitelistEntry_POST_unknownContainer() throws Exception {
+    String json =
+        "{\"fabId\":\"publisher/app\",\"fabVersion\":\"1.0.0\",\"fabHash\":\""
+            + "a".repeat(64)
+            + "\"}";
+
+    mockMvc
+        .perform(
+            post("/containers/does-not-exist/fab-whitelist")
+                .content(json)
+                .contentType(APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isNotFound());
   }
 
   @Test

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
@@ -23,7 +23,9 @@ import org.molgenis.armadillo.container.FlowerSuperexecContainerConfig;
 import org.molgenis.armadillo.container.FlowerSupernodeContainerConfig;
 import org.molgenis.armadillo.container.VanillaContainerConfig;
 import org.molgenis.armadillo.container.VanillaContainerUpdater;
+import org.molgenis.armadillo.container.WhitelistedApp;
 import org.molgenis.armadillo.exceptions.DefaultContainerDeleteException;
+import org.molgenis.armadillo.exceptions.InvalidFabWhitelistEntryException;
 import org.molgenis.armadillo.exceptions.UnknownContainerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -442,6 +444,158 @@ class ContainerServiceTest {
     containerService.upsert(config);
 
     assertTrue(Files.exists(fabWhitelist));
+  }
+
+  private ContainerService containerServiceWithDefault(ContainersMetadata containersMetadata) {
+    containersMetadata
+        .getContainers()
+        .put(
+            "default",
+            VanillaContainerConfig.create(
+                "default",
+                "image",
+                "localhost",
+                6311,
+                null,
+                null,
+                null,
+                List.of(),
+                Map.of(),
+                null,
+                null,
+                null,
+                null));
+
+    var containerService =
+        new ContainerService(
+            new DummyContainersLoader(containersMetadata),
+            initialContainerConfigs,
+            containerScope,
+            List.of(),
+            mock(DefaultContainerFactory.class),
+            List.of());
+    containerService.initialize();
+    return containerService;
+  }
+
+  @Test
+  void upsert_writesFabWhitelistToYamlFile(@TempDir Path tempDir) throws java.io.IOException {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    var config =
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .fabWhitelist(List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))))
+            .build();
+
+    containerService.upsert(config);
+
+    String content = Files.readString(fabWhitelist);
+    assertTrue(content.contains("fab_id: \"@publisher/app\""));
+    assertTrue(content.contains("fab_version: \"1.0.0\""));
+    assertTrue(content.contains("fab_hash: \"" + "a".repeat(64) + "\""));
+  }
+
+  @Test
+  void addFabWhitelistEntry_appendsNewEntry(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "@publisher/app", "1.0.0", "a".repeat(64));
+
+    var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
+    assertEquals(
+        List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))),
+        updated.getFabWhitelist());
+  }
+
+  @Test
+  void addFabWhitelistEntry_replacesExistingEntryForSameFabIdAndVersion(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .fabWhitelist(List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))))
+            .build());
+
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "@publisher/app", "1.0.0", "b".repeat(64));
+
+    var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
+    assertEquals(
+        List.of(new WhitelistedApp("@publisher/app", "1.0.0", "b".repeat(64))),
+        updated.getFabWhitelist());
+  }
+
+  @Test
+  void addFabWhitelistEntry_rejectsInvalidFabHash(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    assertThrows(
+        InvalidFabWhitelistEntryException.class,
+        () ->
+            containerService.addFabWhitelistEntry(
+                "flower-clientapp-1", "@publisher/app", "1.0.0", "not-a-hash"));
+  }
+
+  @Test
+  void addFabWhitelistEntry_rejectsInvalidFabId(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    assertThrows(
+        InvalidFabWhitelistEntryException.class,
+        () ->
+            containerService.addFabWhitelistEntry(
+                "flower-clientapp-1", "not-an-app-id", "1.0.0", "a".repeat(64)));
+  }
+
+  @Test
+  void addFabWhitelistEntry_rejectsNonSuperexecContainer() {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            containerService.addFabWhitelistEntry(
+                "default", "@publisher/app", "1.0.0", "a".repeat(64)));
+  }
+
+  @Test
+  void addFabWhitelistEntry_throwsForUnknownContainer() {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+
+    assertThrows(
+        UnknownContainerException.class,
+        () ->
+            containerService.addFabWhitelistEntry(
+                "does-not-exist", "@publisher/app", "1.0.0", "a".repeat(64)));
   }
 
   @Test

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
@@ -488,13 +488,13 @@ class ContainerServiceTest {
             .name("flower-clientapp-1")
             .image("flwr/superexec:1.32.1")
             .fabWhitelistPath(fabWhitelist.toString())
-            .fabWhitelist(List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))))
+            .fabWhitelist(List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))))
             .build();
 
     containerService.upsert(config);
 
     String content = Files.readString(fabWhitelist);
-    assertTrue(content.contains("fab_id: \"@publisher/app\""));
+    assertTrue(content.contains("fab_id: \"publisher/app\""));
     assertTrue(content.contains("fab_version: \"1.0.0\""));
     assertTrue(content.contains("fab_hash: \"" + "a".repeat(64) + "\""));
   }
@@ -511,11 +511,11 @@ class ContainerServiceTest {
             .build());
 
     containerService.addFabWhitelistEntry(
-        "flower-clientapp-1", "@publisher/app", "1.0.0", "a".repeat(64));
+        "flower-clientapp-1", "publisher/app", "1.0.0", "a".repeat(64));
 
     var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
     assertEquals(
-        List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))),
+        List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))),
         updated.getFabWhitelist());
   }
 
@@ -528,15 +528,15 @@ class ContainerServiceTest {
             .name("flower-clientapp-1")
             .image("flwr/superexec:1.32.1")
             .fabWhitelistPath(fabWhitelist.toString())
-            .fabWhitelist(List.of(new WhitelistedApp("@publisher/app", "1.0.0", "a".repeat(64))))
+            .fabWhitelist(List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))))
             .build());
 
     containerService.addFabWhitelistEntry(
-        "flower-clientapp-1", "@publisher/app", "1.0.0", "b".repeat(64));
+        "flower-clientapp-1", "publisher/app", "1.0.0", "b".repeat(64));
 
     var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
     assertEquals(
-        List.of(new WhitelistedApp("@publisher/app", "1.0.0", "b".repeat(64))),
+        List.of(new WhitelistedApp("publisher/app", "1.0.0", "b".repeat(64))),
         updated.getFabWhitelist());
   }
 
@@ -555,7 +555,7 @@ class ContainerServiceTest {
         InvalidFabWhitelistEntryException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "flower-clientapp-1", "@publisher/app", "1.0.0", "not-a-hash"));
+                "flower-clientapp-1", "publisher/app", "1.0.0", "not-a-hash"));
   }
 
   @Test
@@ -577,6 +577,31 @@ class ContainerServiceTest {
   }
 
   @Test
+  void addFabWhitelistEntry_acceptsRealFabIdFormatWithoutAtPrefix(@TempDir Path tempDir) {
+    // Regression test: flwr.cli.config_utils.get_metadata_from_config builds fab_id as
+    // "publisher/name" — no leading "@" (that only appears in Hub specifiers like
+    // "@account/app", never in a FAB's own declared metadata). Confirmed against a real
+    // FAB (2026-08-17); a stricter "@publisher/name" pattern would reject every
+    // legitimately-approved app.
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    assertDoesNotThrow(
+        () ->
+            containerService.addFabWhitelistEntry(
+                "flower-clientapp-1",
+                "timmyjc/quickstart-pytorch-armadillo",
+                "1.0.3",
+                "a".repeat(64)));
+  }
+
+  @Test
   void addFabWhitelistEntry_rejectsNonSuperexecContainer() {
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
 
@@ -584,7 +609,7 @@ class ContainerServiceTest {
         IllegalArgumentException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "default", "@publisher/app", "1.0.0", "a".repeat(64)));
+                "default", "publisher/app", "1.0.0", "a".repeat(64)));
   }
 
   @Test
@@ -595,7 +620,7 @@ class ContainerServiceTest {
         UnknownContainerException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "does-not-exist", "@publisher/app", "1.0.0", "a".repeat(64)));
+                "does-not-exist", "publisher/app", "1.0.0", "a".repeat(64)));
   }
 
   @Test

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
@@ -479,24 +479,49 @@ class ContainerServiceTest {
   }
 
   @Test
-  void upsert_writesFabWhitelistToYamlFile(@TempDir Path tempDir) throws java.io.IOException {
+  void addFabWhitelistEntry_writesFabWhitelistToYamlFile(@TempDir Path tempDir)
+      throws java.io.IOException {
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
-
     Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
-    var config =
+    containerService.upsert(
         FlowerSuperexecContainerConfig.builder()
             .name("flower-clientapp-1")
             .image("flwr/superexec:1.32.1")
             .fabWhitelistPath(fabWhitelist.toString())
-            .fabWhitelist(List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))))
-            .build();
+            .build());
 
-    containerService.upsert(config);
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "publisher/app", "1.0.0", "a".repeat(64));
 
     String content = Files.readString(fabWhitelist);
     assertTrue(content.contains("fab_id: \"publisher/app\""));
     assertTrue(content.contains("fab_version: \"1.0.0\""));
     assertTrue(content.contains("fab_hash: \"" + "a".repeat(64) + "\""));
+  }
+
+  @Test
+  void upsert_ofExistingSuperexecContainerDoesNotOverwriteFabWhitelistFile(@TempDir Path tempDir)
+      throws java.io.IOException {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "publisher/app", "1.0.0", "a".repeat(64));
+    String before = Files.readString(fabWhitelist);
+
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.2")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    assertEquals(before, Files.readString(fabWhitelist));
   }
 
   @Test
@@ -577,12 +602,50 @@ class ContainerServiceTest {
   }
 
   @Test
+  void addFabWhitelistEntry_rejectsBlankFabVersion(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .build());
+
+    assertThrows(
+        InvalidFabWhitelistEntryException.class,
+        () ->
+            containerService.addFabWhitelistEntry(
+                "flower-clientapp-1", "publisher/app", " ", "a".repeat(64)));
+  }
+
+  @Test
+  void addFabWhitelistEntry_replacesEntryWithNullFabVersionWithoutThrowing(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(fabWhitelist.toString())
+            .fabWhitelist(List.of(new WhitelistedApp("publisher/app", null, "a".repeat(64))))
+            .build());
+
+    assertDoesNotThrow(
+        () ->
+            containerService.addFabWhitelistEntry(
+                "flower-clientapp-1", "publisher/app", "1.0.0", "b".repeat(64)));
+
+    var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
+    assertEquals(
+        List.of(
+            new WhitelistedApp("publisher/app", null, "a".repeat(64)),
+            new WhitelistedApp("publisher/app", "1.0.0", "b".repeat(64))),
+        updated.getFabWhitelist());
+  }
+
+  @Test
   void addFabWhitelistEntry_acceptsRealFabIdFormatWithoutAtPrefix(@TempDir Path tempDir) {
-    // Regression test: flwr.cli.config_utils.get_metadata_from_config builds fab_id as
-    // "publisher/name" — no leading "@" (that only appears in Hub specifiers like
-    // "@account/app", never in a FAB's own declared metadata). Confirmed against a real
-    // FAB (2026-08-17); a stricter "@publisher/name" pattern would reject every
-    // legitimately-approved app.
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
     Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
     containerService.upsert(

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
@@ -594,11 +594,12 @@ class ContainerServiceTest {
             .fabWhitelistPath(fabWhitelist.toString())
             .build());
 
+    String fabHash = "a".repeat(64);
     assertThrows(
         InvalidFabWhitelistEntryException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "flower-clientapp-1", "not-an-app-id", "1.0.0", "a".repeat(64)));
+                "flower-clientapp-1", "not-an-app-id", "1.0.0", fabHash));
   }
 
   @Test
@@ -612,11 +613,12 @@ class ContainerServiceTest {
             .fabWhitelistPath(fabWhitelist.toString())
             .build());
 
+    String fabHash = "a".repeat(64);
     assertThrows(
         InvalidFabWhitelistEntryException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "flower-clientapp-1", "publisher/app", " ", "a".repeat(64)));
+                "flower-clientapp-1", "publisher/app", " ", fabHash));
   }
 
   @Test
@@ -668,22 +670,22 @@ class ContainerServiceTest {
   void addFabWhitelistEntry_rejectsNonSuperexecContainer() {
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
 
+    String fabHash = "a".repeat(64);
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            containerService.addFabWhitelistEntry(
-                "default", "publisher/app", "1.0.0", "a".repeat(64)));
+        () -> containerService.addFabWhitelistEntry("default", "publisher/app", "1.0.0", fabHash));
   }
 
   @Test
   void addFabWhitelistEntry_throwsForUnknownContainer() {
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
 
+    String fabHash = "a".repeat(64);
     assertThrows(
         UnknownContainerException.class,
         () ->
             containerService.addFabWhitelistEntry(
-                "does-not-exist", "publisher/app", "1.0.0", "a".repeat(64)));
+                "does-not-exist", "publisher/app", "1.0.0", fabHash));
   }
 
   @Test

--- a/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
+++ b/armadillo/src/test/java/org/molgenis/armadillo/metadata/ContainerServiceTest.java
@@ -26,6 +26,7 @@ import org.molgenis.armadillo.container.VanillaContainerUpdater;
 import org.molgenis.armadillo.container.WhitelistedApp;
 import org.molgenis.armadillo.exceptions.DefaultContainerDeleteException;
 import org.molgenis.armadillo.exceptions.InvalidFabWhitelistEntryException;
+import org.molgenis.armadillo.exceptions.NotFlowerSuperexecContainerException;
 import org.molgenis.armadillo.exceptions.UnknownContainerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -500,7 +501,7 @@ class ContainerServiceTest {
   }
 
   @Test
-  void upsert_ofExistingSuperexecContainerDoesNotOverwriteFabWhitelistFile(@TempDir Path tempDir)
+  void upsert_ofExistingSuperexecContainerKeepsFabWhitelist(@TempDir Path tempDir)
       throws java.io.IOException {
     var containerService = containerServiceWithDefault(ContainersMetadata.create());
     Path fabWhitelist = tempDir.resolve("fab-whitelist.yaml");
@@ -521,7 +522,52 @@ class ContainerServiceTest {
             .fabWhitelistPath(fabWhitelist.toString())
             .build());
 
+    var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
+    assertEquals(
+        List.of(new WhitelistedApp("publisher/app", "1.0.0", "a".repeat(64))),
+        updated.getFabWhitelist());
     assertEquals(before, Files.readString(fabWhitelist));
+  }
+
+  @Test
+  void upsert_withNewFabWhitelistPathWritesWhitelistThere(@TempDir Path tempDir)
+      throws java.io.IOException {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(tempDir.resolve("old.yaml").toString())
+            .build());
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "publisher/app", "1.0.0", "a".repeat(64));
+
+    Path newPath = tempDir.resolve("new/fab-whitelist.yaml");
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(newPath.toString())
+            .build());
+
+    assertTrue(Files.readString(newPath).contains("fab_hash: \"" + "a".repeat(64) + "\""));
+  }
+
+  @Test
+  void addFabWhitelistEntry_storesHashInLowerCase(@TempDir Path tempDir) {
+    var containerService = containerServiceWithDefault(ContainersMetadata.create());
+    containerService.upsert(
+        FlowerSuperexecContainerConfig.builder()
+            .name("flower-clientapp-1")
+            .image("flwr/superexec:1.32.1")
+            .fabWhitelistPath(tempDir.resolve("fab-whitelist.yaml").toString())
+            .build());
+
+    containerService.addFabWhitelistEntry(
+        "flower-clientapp-1", "publisher/app", "1.0.0", "A".repeat(64));
+
+    var updated = (FlowerSuperexecContainerConfig) containerService.getByName("flower-clientapp-1");
+    assertEquals("a".repeat(64), updated.getFabWhitelist().get(0).fabHash());
   }
 
   @Test
@@ -672,7 +718,7 @@ class ContainerServiceTest {
 
     String fabHash = "a".repeat(64);
     assertThrows(
-        IllegalArgumentException.class,
+        NotFlowerSuperexecContainerException.class,
         () -> containerService.addFabWhitelistEntry("default", "publisher/app", "1.0.0", fabHash));
   }
 


### PR DESCRIPTION
## Background
The custom SuperExec image (molgenis-flwr-armadillo #11) only runs ClientApps whose FAB (Flower App Bundle) hash appears in a whitelist file. `FlowerSuperexecContainerConfig` already stored `fabWhitelistPath`, the location of that file, but there was no way to manage its contents or approve an app, short of editing the YAML by hand.

## What's changed
- `WhitelistedApp`: new record holding a single whitelist entry: `fabId`, `fabVersion`, `fabHash`
- `FlowerSuperexecContainerConfig` gains a `fabWhitelist` field (`List<WhitelistedApp>`, defaults to `List.of()`)
- `ContainerService.addFabWhitelistEntry(containerName, fabId, fabVersion, fabHash)`: adds or replaces the entry for a given `(fabId, fabVersion)` pair (re-approving a version replaces its previous hash rather than adding a duplicate), saves it, and rewrites the container's whitelist YAML file (`fab_id`/`fab_version`/`fab_hash` keys, matching Flower's own FAB metadata) so the file matches `containers.json`. Hashes are stored in lower case, as Flower produces them.
- A general container save (e.g. `PUT /containers` from the UI) keeps the stored whitelist and rewrites the file from it, so an unrelated edit can't wipe approvals and the file always matches the settings.
- Validation, all returning `400`: `fabHash` must be a 64-character hex SHA-256; `fabId` must match Flower's `publisher/name` format (no leading `@`, which only appears in Hub specifiers such as `@account/app`); `fabVersion` must not be blank; a container that isn't a SuperExec container is rejected (`NotFlowerSuperexecContainerException`, from #986). Unknown containers return `404`.
- `POST /containers/{name}/fab-whitelist`: new endpoint on `ContainersController` exposing the above, `ROLE_SU` only, audited as `ADD_FAB_WHITELIST_ENTRY` with the container and the approved `fabId`, `fabVersion` and `fabHash`

## How to test
```bash
./gradlew :armadillo:test --tests '*ContainerServiceTest' --tests '*ContainersControllerTest'

# Image built as in #985: superexec-armadillo:test

# 1. Start from a clean slate
rm -rf data/system/flower/

# 2. Register a flower-superexec container (writes an empty whitelist file)
jq -n '{type:"flower-superexec", name:"test-clientapp", image:"superexec-armadillo:test",
  dockerArgs:["--insecure","--appio-api-address","test-supernode:9094"]}' > /tmp/clientapp.json
curl -u admin:admin -X PUT http://localhost:8080/containers \
  -H "Content-Type: application/json" -d @/tmp/clientapp.json
# expect: 204

# 3. Confirm the whitelist file is empty
cat data/system/flower/test-clientapp-fab-whitelist.yaml
# expect: []

# 4. Approve a FAB hash via the new endpoint (an upper-case hash is stored in lower case)
curl -u admin:admin -X POST http://localhost:8080/containers/test-clientapp/fab-whitelist \
  -H "Content-Type: application/json" \
  -d '{"fabId":"publisher/app","fabVersion":"1.0.0","fabHash":"'"$(printf 'A%.0s' {1..64})"'"}'
# expect: 204
cat data/system/flower/test-clientapp-fab-whitelist.yaml
# expect: one fab_id/fab_version/fab_hash entry, hash in lower case

# 5. An unrelated edit to the container keeps the whitelist
jq '.dockerArgs[2] = "test-supernode:9095"' /tmp/clientapp.json > /tmp/clientapp-edit.json
curl -u admin:admin -X PUT http://localhost:8080/containers \
  -H "Content-Type: application/json" -d @/tmp/clientapp-edit.json
# expect: 204
cat data/system/flower/test-clientapp-fab-whitelist.yaml
# expect: the entry from step 4 is still present

# 6. Reject an invalid entry, and a container that isn't a SuperExec container
curl -u admin:admin -X POST http://localhost:8080/containers/test-clientapp/fab-whitelist \
  -H "Content-Type: application/json" \
  -d '{"fabId":"not-an-app-id","fabVersion":"1.0.0","fabHash":"not-a-hash"}'
# expect: 400
curl -u admin:admin -X POST http://localhost:8080/containers/default/fab-whitelist \
  -H "Content-Type: application/json" \
  -d '{"fabId":"publisher/app","fabVersion":"1.0.0","fabHash":"'"$(printf 'a%.0s' {1..64})"'"}'
# expect: 400

# 7. Cleanup
curl -u admin:admin -X DELETE http://localhost:8080/containers/test-clientapp
rm -rf data/system/flower/ /tmp/clientapp.json /tmp/clientapp-edit.json
```