### PR TITLE
fix: only use dev BuildProperties fallback when build info is missing

### DIFF
--- a/armadillo/src/main/java/org/molgenis/armadillo/config/BuildPropertiesFallbackConfig.java
+++ b/armadillo/src/main/java/org/molgenis/armadillo/config/BuildPropertiesFallbackConfig.java
@@ -1,13 +1,16 @@
 package org.molgenis.armadillo.config;
 
 import java.util.Properties;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @Configuration
-@ConditionalOnMissingBean(BuildProperties.class)
+@Conditional(BuildPropertiesFallbackConfig.BuildInfoMissing.class)
 public class BuildPropertiesFallbackConfig {
 
   @Bean
@@ -15,5 +18,15 @@ public class BuildPropertiesFallbackConfig {
     Properties props = new Properties();
     props.setProperty("version", "dev");
     return new BuildProperties(props);
+  }
+
+  static class BuildInfoMissing implements Condition {
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+      return !context
+          .getResourceLoader()
+          .getResource("classpath:META-INF/build-info.properties")
+          .exists();
+    }
   }
 }


### PR DESCRIPTION
## Background                                                                                                                                                          
                                                                                                                                                                         
  The `dev` fallback `BuildProperties` bean added in #1fa082b (so the app can be started from an                                                                         
  IDE without a prior Gradle build) was guarded with `@ConditionalOnMissingBean`. That annotation is                                                                     
  only reliable on auto-configuration classes: user `@Configuration` classes are parsed *before*                                                                         
  Spring Boot's `ProjectInfoAutoConfiguration` registers the real `BuildProperties`, so the condition                                                                    
  always matched. The fallback bean was therefore registered in every run and the real build info                                                                        
  backed off, leaving properly built jars reporting version `dev`.                                                                                                       
                                                                                                                                                                         
  ## What's changed                                                                                                                                                      
                                                                                                                                                                         
  - Replaced `@ConditionalOnMissingBean(BuildProperties.class)` with a custom `Condition`                                                                                
    (`BuildPropertiesFallbackConfig.BuildInfoMissing`) that checks for                                                                                                   
    `classpath:META-INF/build-info.properties` directly.                                                                                                                 
  - The fallback bean is now only created when Gradle's `buildInfo()` output is genuinely absent                                                                         
    (i.e. IDE runs without a build), independent of bean registration order.

 ## How to test                                                                                                                                                                                                                                                                                                              
- [ ] Code review
- [ ] Functional test: check preview (https://preview-armadillo-pr-1078.dev.molgenis.org/) displays `v5.17.3-snapshot`

Note sonar comments refer to previous commit, not related to this PR.                                                                                                                                         
 